### PR TITLE
Sync on new namespaces if it matches the pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM flag5/clustersecretbase:0.0.1
+FROM flag5/clustersecretbase:0.0.2
 ADD /src /src
 CMD kopf run /src/handlers.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMG_NAMESPACE = flag5
 IMG_NAME = clustersecret
 IMG_FQNAME = $(IMG_NAMESPACE)/$(IMG_NAME)
-IMG_VERSION = 0.0.1
+IMG_VERSION = 0.0.2
 
 .PHONY: container push clean
 all: container push

--- a/base-image/Makefile
+++ b/base-image/Makefile
@@ -1,7 +1,7 @@
 IMG_NAMESPACE = flag5
 IMG_NAME = clustersecretbase
 IMG_FQNAME = $(IMG_NAMESPACE)/$(IMG_NAME)
-IMG_VERSION = 0.0.1
+IMG_VERSION = 0.0.2
 
 .PHONY: container push clean
 all: container push

--- a/base-image/requirements.txt
+++ b/base-image/requirements.txt
@@ -1,2 +1,2 @@
-kopf
+kopf===0.27rc6
 kubernetes

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -13,30 +13,51 @@ def on_delete(spec,body,name,logger=None, **_):
             v1.delete_namespaced_secret(name,ns)
         except client.rest.ApiException as e:
             logger.error(f"Something failed trying to delete the secret {e}")
-            
-        
+
 @kopf.on.field('clustersecret.io', 'v1', 'clustersecrets', field='data')
 def on_field_data(old, new, body,name,logger=None, **_):
     logger.info(f'Data changed: {old} -> {new}')
     syncedns = body['status']['create_fn']['syncedns']
     v1 = client.CoreV1Api()
     for ns in syncedns:
-        logger.info(f'patching secret {name} in ns {ns}')
+        logger.info(f'Re Syncing secret {name} in ns {ns}')
         metadata = {'name': name, 'namespace': ns}
         api_version = 'v1'
         kind = 'Secret'
         data = new
-        body = client.V1Secret(api_version, data , kind, metadata,)
+        body = client.V1Secret(api_version, data , kind, metadata)
         # response = v1.patch_namespaced_secret(name,ns,body)
         response = v1.replace_namespaced_secret(name,ns,body)
         logger.debug(response)
-        
-    
+
+csecs = {} # all cluster secrets.
 
 @kopf.on.resume('clustersecret.io', 'v1', 'clustersecrets')
 @kopf.on.create('clustersecret.io', 'v1', 'clustersecrets')
-def create_fn(spec,logger=None,body=None,**kwargs):
+async def create_fn(spec,uid,logger=None,body=None,**kwargs):
+    v1 = client.CoreV1Api()
+    
+    #get all ns matching.
+    matchedns = get_ns_list(logger,body,v1)
+        
+    #sync in all matched NS
+    logger.info(f'Syncing on Namespaces: {matchedns}')
+    for namespace in matchedns:
+        create_secret(logger,namespace,body,v1)
+    
+    #store status in memory
+    csecs[uid]={}
+    csecs[uid]['body']=body
+    
+    return {'syncedns': matchedns}
 
+def get_ns_list(logger,body,v1=None):
+    """Returns a list of namespaces where the secret should be matched
+    """
+    if v1 is None:
+        v1 = client.CoreV1Api()
+        logger.debug('new client - fn get_ns_list')
+    
     try:
         matchNamespace = body.get('matchNamespace')
     except KeyError:
@@ -46,13 +67,36 @@ def create_fn(spec,logger=None,body=None,**kwargs):
     
     try:
         avoidNamespaces = body.get('avoidNamespaces')
-        logger.debug (f'Avoiding : {avoidNamespaces}')
-        if avoidNamespaces == None:
-            avoidNamespaces = []
     except KeyError:
         avoidNamespaces = ''
-        logger.debug("not avoiding any namespaces")
-        
+        logger.debug("not avoiding namespaces")
+
+    nss = v1.list_namespace().items
+    matchedns = []
+    avoidedns = []
+
+    for matchns in matchNamespace:
+        for ns in nss:
+            if re.match(matchns, ns.metadata.name):
+                matchedns.append(ns.metadata.name)
+                logger.debug(f'Matched namespaces: {ns.metadata.name} matchpathern: {matchns}')   
+    for avoidns in avoidNamespaces:
+        for ns in nss:
+            if re.match(avoidns, ns.metadata.name):
+                avoidedns.append(ns.metadata.name)
+                logger.debug(f'Skipping namespaces: {ns.metadata.name} avoidpatrn: {avoidns}')  
+    # purge
+    for ns in matchedns:
+        if ns in avoidedns:
+            matchedns.remove(ns)
+
+    return matchedns
+    
+            
+def create_secret(logger,namespace,body,v1=None):
+    if v1 is None:
+        v1 = client.CoreV1Api()
+        logger.debug('new client - fn create secret')
     try:
         name = body['metadata']['name']
     except KeyError:
@@ -62,58 +106,40 @@ def create_fn(spec,logger=None,body=None,**kwargs):
         data = body.get('data')
     except KeyError:
         data = ''
-        logger.debug("Empty secret??")
-
-    v1 = client.CoreV1Api()
+        logger.error("Empty secret?? could not get the data.")
     
-    matchedns = get_ns_list(v1,logger,matchNamespace,avoidNamespaces)
-    
-    #sync in all matched NS
-    for ns in matchedns:
-        create_secret(v1,logger,ns,name,data)
-    return {'syncedns': matchedns}
-
-
-
-
-def get_ns_list(v1,logger,matchNamespace,avoidNamespaces):
-    nss = v1.list_namespace().items
-    matchedns = []
-    avoidedns = []
-    
-    for matchns in matchNamespace:
-        for ns in nss:
-            if re.match(matchns, ns.metadata.name):
-                matchedns.append(ns.metadata.name)
-                logger.info(f'Matched namespaces: {ns.metadata.name} matchpathern: {matchns}')
-    for avoidns in avoidNamespaces:
-        for ns in nss:
-            if re.match(avoidns, ns.metadata.name):
-                avoidedns.append(ns.metadata.name)
-                logger.info(f'Skipping namespaces: {ns.metadata.name} avoidpatrn: {avoidns}')  
-    # purge
-    for ns in matchedns:
-        if ns in avoidedns:
-            matchedns.remove(ns)
-    
-    logger.info(f'Syncing on Namespaces: {matchedns}')
-    return matchedns
-    
-            
-def create_secret(v1,logger,namespace,name,data):
     metadata = {'name': name, 'namespace': namespace}
     api_version = 'v1'
     kind = 'Secret'
     body = client.V1Secret(api_version, data , kind, metadata)
     # kopf.adopt(body)
+    logger.info(f"clonning secret in namespace {namespace}")
     try:
         api_response = v1.create_namespaced_secret(namespace, body)
     except client.rest.ApiException as e:
         if e.reason == 'Conflict':
-            logger.info(f"Conflict creating the secret: It may be already a `{name}` secret in namespace: '{namespace}'")
+            logger.warning(f"secret `{name}` already exist in namesace '{namespace}'")
             return 0
-        logger.error(f'Can not create a secret, it is base64 encoded? ')
-        # uncoment next line for debug, not por production. (avoid send secrets to logs)
-        # logger.error(f'Kube exception {e}')
+        logger.error(f'Can not create a secret, it is base64 encoded? data: {data}')
+        logger.error(f'Kube exception {e}')
         return 1
     return 0
+
+@kopf.on.create('', 'v1', 'namespaces')
+async def namespace_watcher(patch,logger,meta,body,event,**kwargs):
+    new_ns = meta['name']
+    logger.debug(f"New namespace created: {new_ns} re-syncing")
+    v1 = client.CoreV1Api()
+    
+    for k,v in csecs.items():
+        obj_body = v['body']
+        # logger.debug(f'k: {k} \n v:{v}')
+        matcheddns = v['body']['status']['create_fn']['syncedns']
+        logger.debug(f"Old matcheddns: {matcheddns}")
+        logger.debug(f"name: {v['body']['metadata']['name']}")
+        ns_new_list=get_ns_list(logger,obj_body,v1)
+        logger.debug(f"new matched list: {ns_new_list}")
+        if new_ns in ns_new_list:
+            logger.debug(f"Clonning secret {v['body']['metadata']['name']} into the new namespace {new_ns}")
+            create_secret(logger,new_ns,body,v1)
+            v['body']['status']['create_fn']['syncedns'] = ns_new_list

--- a/yaml/02_deployment.yaml
+++ b/yaml/02_deployment.yaml
@@ -25,5 +25,5 @@ spec:
         # - name: regcred
         containers:
         - name: clustersecret
-          image: flag5/clustersecret:latest
+          image: flag5/clustersecret:0.0.2
           imagePullPolicy: Always

--- a/yaml/02_deployment.yaml
+++ b/yaml/02_deployment.yaml
@@ -26,4 +26,4 @@ spec:
         containers:
         - name: clustersecret
           image: flag5/clustersecret:0.0.2
-          imagePullPolicy: Always
+          # imagePullPolicy: Always

--- a/yaml/Object_example/obj2.yaml
+++ b/yaml/Object_example/obj2.yaml
@@ -1,0 +1,10 @@
+# A demo custom resource for the Kopf example operators.
+apiVersion: clustersecret.io/v1
+kind: ClusterSecret
+metadata:
+  name: global-secret2
+matchNamespace:
+  - cluster*
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm


### PR DESCRIPTION
With this pr now we listen on new namespace creations.
if the new namespace match the any pattern of all ClusterSecrets  they will also be available there.

- [x] refactor code
- [x] react to new namespace creation
- [x] bump to version 0.0.2

Changelog:
requiered Kopf=0.27rc6
https://github.com/zalando-incubator/kopf/releases/tag/0.27rc6

Thanks to @nolar https://github.com/zalando-incubator/kopf/issues/365
