### PR TITLE
Fix issue 2

### DIFF
--- a/yaml/00_rbac.yaml
+++ b/yaml/00_rbac.yaml
@@ -53,11 +53,6 @@ rules:
     resources: [events]
     verbs: [create]
 
-  # Application: watching & handling for the custom resource we declare.
-  - apiGroups: [clustersecret.io]
-    resources: [redmineissues]
-    verbs: [list, watch, patch]
-
   # Application: other resources it produces and manipulates.
   # Here, we create secrets, but we do not delete them ever.
   - apiGroups: [batch, extensions]

--- a/yaml/00_rbac.yaml
+++ b/yaml/00_rbac.yaml
@@ -17,7 +17,7 @@ rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
   - apiGroups: [clustersecret.io]
-    resources: [clustersecret]
+    resources: [clustersecrets]
     verbs: [list, watch, patch, get]
   - apiGroups: [clustersecret.io]
     resources: [customresourcedefinitions]
@@ -27,6 +27,11 @@ rules:
   - apiGroups: [clustersecret.io]
     resources: [clustersecret]
     verbs: [list, watch]
+    
+  # Watch naespaces 
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [watch, list, get]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/yaml/00_rbac.yaml
+++ b/yaml/00_rbac.yaml
@@ -17,7 +17,7 @@ rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
   - apiGroups: [clustersecret.io]
-    resources: [clustersecrets]
+    resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
   - apiGroups: [clustersecret.io]
     resources: [customresourcedefinitions]
@@ -25,13 +25,18 @@ rules:
 
   # Application: read-only access for watching cluster-wide.
   - apiGroups: [clustersecret.io]
-    resources: [clustersecret]
+    resources: [clustersecrets]
     verbs: [list, watch]
     
   # Watch naespaces 
   - apiGroups: [""]
     resources: [namespaces]
     verbs: [watch, list, get]
+    
+  # Handle secrets 
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [watch, list, get, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -55,9 +60,6 @@ rules:
 
   # Application: other resources it produces and manipulates.
   # Here, we create secrets, but we do not delete them ever.
-  - apiGroups: [batch, extensions]
-    resources: [jobs]
-    verbs: [create]
   - apiGroups: [""]
     resources: [secrets]
     verbs: [create,update,patch]


### PR DESCRIPTION
Fixes https://github.com/zakkg3/ClusterSecret/issues/2

 * Fixed bad plural name for api object 'clustersecrets'
* Add missing permission to watch namespaces.

Tested on 
 * Kubernetes `15.5` bare metal.
 * Kuberenetes `1.18.2` Minikube

