### PR TITLE
Fix update secrets

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -44,8 +44,13 @@ def on_field_data(old, new, body,name,logger=None, **_):
             api_version = 'v1'
             kind = 'Secret'
             data = new
-            body = client.V1Secret(api_version, data , kind, metadata, type = secret_type)
-            # response = v1.patch_namespaced_secret(name,ns,body)
+            body = client.V1Secret(
+                api_version=api_version,
+                data=data ,
+                kind=kind,
+                metadata=metadata,
+                type = secret_type
+            )
             response = v1.replace_namespaced_secret(name,ns,body)
             logger.debug(response)
     else:

--- a/yaml/01_crd.yaml
+++ b/yaml/01_crd.yaml
@@ -10,6 +10,21 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            matchNamespace:
+              type: array
+              items:
+                type: string
+            avoidNamespaces:
+              type: array
+              items:
+                type: string
+            data:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
         - name: Type
           type: string


### PR DESCRIPTION
V1Secret signature has changed. I've changed all parameters to named to prevent this error in the future

```
In [6]: client.V1Secret?
Init signature:
client.V1Secret(
    api_version=None,
    data=None,
    immutable=None,
    kind=None,
    metadata=None,
    string_data=None,
    type=None,
    local_vars_configuration=None,
)
```

Before the change it was:
```

In [11]: client.V1Secret(
    ...:     "v1", b"data", "Secret", {"name": "name", "namespace": "alpha"}, type="Opaque"
    ...: )
Out[11]: 
{'api_version': 'v1',
 'data': b'data',
 'immutable': 'Secret',
 'kind': {'name': 'name', 'namespace': 'octo-alpha4'},
 'metadata': None,
 'string_data': None,
 'type': 'Opaque'}
```