### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Any change on the ClusterSecret will update all related secrets. Deleting the Cl
 Here is how it looks like:
 
 ```yaml
-Kind: ClusterSecret
+kind: ClusterSecret
 apiVersion: clustersecret.io/v1
 metadata:
   namespace: clustersecret


### PR DESCRIPTION
Fix typo that writes `Kind` instead of `kind` what is not working k8s example.