### PR TITLE
Sync on match namespace changes

### DIFF
--- a/charts/cluster-secret/templates/role-namespaced-rbac.yaml
+++ b/charts/cluster-secret/templates/role-namespaced-rbac.yaml
@@ -34,3 +34,10 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - clustersecret.io
+  resources:
+  - clustersecrets
+  verbs:
+  - get
+  - patch

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -39,7 +39,6 @@ def on_field_match_namespace(old, new, name, namespace, body, uid, logger=None, 
         updated_matched = get_ns_list(logger, body, v1)
         to_add = set(updated_matched).difference(set(syncedns))
         to_remove = set(syncedns).difference(set(updated_matched))
-logger.debug(f'To add: {to_add}, To remove: {to_remove}')
 
         logger.debug(f'Add secret to namespaces: {to_add}, remove from: {to_remove}')
 

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -40,6 +40,8 @@ def on_field_match_namespace(old, new, name, namespace, body, uid, logger=None, 
         to_add = set(updated_matched).difference(set(syncedns))
         to_remove = set(syncedns).difference(set(updated_matched))
 
+        logger.debug(f'Add secret to namespaces: {to_add}, remove from: {to_remove}')
+
         for secret_namespace in to_add:
             create_secret(logger, secret_namespace, body)
         for secret_namespace in to_remove:

--- a/yaml/00_rbac.yaml
+++ b/yaml/00_rbac.yaml
@@ -70,6 +70,11 @@ rules:
   - apiGroups: [""]
     resources: [secrets]
     verbs: [create,update,patch]
+  
+  # Application: get and patch clustersecrets for status patching
+  - apiGroups: [clustersecret.io]
+    resources: [clustersecrets]
+    verbs: [get,patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Add the ability to watch for changes on the `matchNamespace` field to sync to newly added namespaces or remove secrets from namespaces, which have been removed from `matchNamespace`. The change requires additional RBAC permissions to get and patch namespaced clustersecrets because we need to patch the status for synced namespaces maintained by the `create_fn` handler.

This is an important use case for us since we leverage ClusterSecret for TLS secret syncing across namespaces and it's nice to be able to just add a new namespace to the `matchNamespace` list, sync that through a CD tool like ArgoCD and have the secret appear in the new namespace automatically.