### PR TITLE
Feature/e2e testing

### DIFF
--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -1,0 +1,57 @@
+name: Lint and Test Charts
+
+on:
+  push:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+          cache: 'pip' # caching pip dependencies
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Build Docker Image
+        run: docker build -t cluster-secret:${{ github.sha }} .
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.8.0
+
+      - name: Run testing
+        run: kind load docker-image cluster-secret:${{ github.sha }}
+
+      - name: Run helm install
+        run: helm install cluster-secret ./charts/cluster-secret -n cluster-secret --create-namespace --set clustersecret.clustersecret.image.repository=cluster-secret,clustersecret.clustersecret.image.tag=${{ github.sha }}
+
+      - run: pip3 install -r conformance/requirements.txt
+        name: Install python requirements
+
+      - name: Run testing
+        run: python3 conformance/tests.py

--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.8.0
 
-      - name: Run testing
-        run: kind load docker-image cluster-secret:${{ github.sha }}
+      - name: Loading locally build image to kind cluster
+        run: kind load docker-image cluster-secret:${{ github.sha }} --context=chart-testing
 
       - name: Run helm install
         run: helm install cluster-secret ./charts/cluster-secret -n cluster-secret --create-namespace --set clustersecret.clustersecret.image.repository=cluster-secret,clustersecret.clustersecret.image.tag=${{ github.sha }}

--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: E2E Testing
 
 on:
   push:
@@ -45,7 +45,7 @@ jobs:
         uses: helm/kind-action@v1.8.0
 
       - name: Loading locally build image to kind cluster
-        run: kind load docker-image cluster-secret:${{ github.sha }} --context=chart-testing
+        run: kind load docker-image cluster-secret:${{ github.sha }} --name=chart-testing
 
       - name: Run helm install
         run: helm install cluster-secret ./charts/cluster-secret -n cluster-secret --create-namespace --set clustersecret.clustersecret.image.repository=cluster-secret,clustersecret.clustersecret.image.tag=${{ github.sha }}

--- a/conformance/cluster-secrets.yaml
+++ b/conformance/cluster-secrets.yaml
@@ -1,0 +1,27 @@
+apiVersion: clustersecret.io/v1
+kind: ClusterSecret
+metadata:
+  name: basic-cluster-secret
+  namespace: example-1
+data:
+  username: MTIzNDU2Cg==
+  password: MTIzNDU2Cg==
+---
+kind: ClusterSecret
+apiVersion: clustersecret.io/v1
+metadata:
+  name: typed-secret
+  namespace: example-1
+  type: kubernetes.io/tls
+data:
+  tls.crt: MTIzNDU2Cg==
+  tls.key: MTIzNDU2Cg==
+---
+apiVersion: clustersecret.io/v1
+kind: ClusterSecret
+metadata:
+  name: basic-cluster-secret
+  namespace: example-1
+avoidNamespaces:
+  - example-3
+---

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -1,6 +1,9 @@
 import time
+from typing import Dict, Optional, List, Callable
 from kubernetes import client, config
+from kubernetes.client import V1Secret, CoreV1Api, CustomObjectsApi
 from kubernetes.client.rest import ApiException
+from time import sleep
 
 
 def wait_for_pod_ready_with_events(pod_selector: dict, namespace: str, timeout_seconds: int = 300):
@@ -44,3 +47,125 @@ def wait_for_pod_ready_with_events(pod_selector: dict, namespace: str, timeout_s
 
     raise TimeoutError(f"Timed out waiting for pod to become ready in namespace {namespace}")
 
+
+class ClusterSecretManager:
+    def __init__(self, custom_objects_api: CustomObjectsApi, api_instance: CoreV1Api):
+        self.custom_objects_api: CustomObjectsApi = custom_objects_api
+        self.api_instance: CoreV1Api = api_instance
+        self.retry_attempts = 3
+        self.retry_delay = 5
+
+    def create_cluster_secret(
+            self,
+            name: str,
+            namespace: str,
+            data: Dict[str, str],
+            labels: Optional[Dict[str, str]] = None,
+            annotations: Optional[Dict[str, str]] = None,
+            match_namespace: Optional[List[str]] = None,
+            avoid_namespaces: Optional[List[str]] = None,
+    ):
+        return self.custom_objects_api.create_namespaced_custom_object(
+            group="clustersecret.io",
+            version="v1",
+            namespace=namespace,
+            body={
+                "apiVersion": "clustersecret.io/v1",
+                "kind": "ClusterSecret",
+                "metadata": {"name": name, "labels": labels, "annotations": annotations},
+                "data": data,
+                "matchNamespace": match_namespace,
+                "avoidNamespaces": avoid_namespaces,
+            },
+            plural="clustersecrets",
+        )
+
+    def update_data_cluster_secret(
+            self,
+            name: str,
+            namespace: str,
+            data: Dict[str, str],
+            match_namespace: Optional[List[str]] = None,
+            avoid_namespaces: Optional[List[str]] = None,
+    ):
+        self.custom_objects_api.patch_namespaced_custom_object(
+            name=name,
+            group="clustersecret.io",
+            version="v1",
+            namespace=namespace,
+            body={
+                "apiVersion": "clustersecret.io/v1",
+                "kind": "ClusterSecret",
+                "data": data,
+                "matchNamespace": match_namespace,
+                "avoidNamespaces": avoid_namespaces,
+            },
+            plural="clustersecrets",
+        )
+
+    def delete_cluster_secret(
+            self,
+            name: str,
+            namespace: str
+    ):
+        self.custom_objects_api.delete_namespaced_custom_object(
+            name=name,
+            group="clustersecret.io",
+            version="v1",
+            namespace=namespace,
+            plural="clustersecrets",
+        )
+
+    def get_kubernetes_secret(self, name: str, namespace: str) -> Optional[V1Secret]:
+        try:
+            return self.api_instance.read_namespaced_secret(name, namespace)
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            else:
+                raise e
+
+    def validate_namespace_secrets(
+            self, name: str,
+            data: Dict[str, str],
+            namespaces: Optional[List[str]] = None
+    ) -> bool:
+        """
+
+        Parameters
+        ----------
+        name
+        data
+        namespaces: Optional[List[str]]
+            If None, it means the secret should be present in ALL namespaces
+
+        Returns
+        -------
+
+        """
+        all_namespaces = [item.metadata.name for item in self.api_instance.list_namespace().items]
+
+        def validate():
+            for namespace in all_namespaces:
+
+                secret = self.get_kubernetes_secret(name=name, namespace=namespace)
+
+                if namespaces is not None and namespace not in namespaces:
+                    if secret is None:
+                        continue
+                    return False
+
+                if secret is None or secret.data != data:
+                    return False
+
+            return True
+
+        return self.retry(validate)
+
+    def retry(self, f: Callable[[], bool]) -> bool:
+        while self.retry_attempts > 0:
+            if f():
+                return True
+            sleep(self.retry_delay)
+            self.retry_attempts -= 1
+        return False

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -1,0 +1,46 @@
+import time
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+
+def wait_for_pod_ready_with_events(pod_selector: dict, namespace: str, timeout_seconds: int = 300):
+    """
+    Wait for a pod to be ready in the specified namespace and print all events.
+
+    Args:
+        pod_selector (dict): A dictionary representing the pod selector (e.g., {"app": "my-app"}).
+        namespace (str): The namespace where the pod is located.
+        timeout_seconds (int): Maximum time to wait for the pod to become ready (default: 300 seconds).
+
+    Raises:
+        TimeoutError: If the specified pod does not become ready within the timeout.
+    """
+    config.load_kube_config()
+    v1 = client.CoreV1Api()
+
+    end_time = time.time() + timeout_seconds
+
+    while time.time() < end_time:
+        pod_list = v1.list_namespaced_pod(
+            namespace,
+            label_selector=','.join([f"{k}={v}" for k, v in pod_selector.items()])
+        )
+
+        for pod in pod_list.items:
+            pod_name = pod.metadata.name
+            print(f"Checking pod {pod_name}...")
+
+            # Print pod events
+            events = v1.list_namespaced_event(namespace, field_selector=f"involvedObject.name={pod_name}")
+            for event in events.items:
+                print(f"Event: {event.message}")
+
+            # Check if the pod is ready
+            if all(status.ready for status in pod.status.container_statuses):
+                print(f"Pod {pod_name} is ready!")
+                return
+
+        time.sleep(5)  # Sleep for a few seconds before checking again
+
+    raise TimeoutError(f"Timed out waiting for pod to become ready in namespace {namespace}")
+

--- a/conformance/namespaces.yaml
+++ b/conformance/namespaces.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-2

--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes===27.2.0

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -1,5 +1,8 @@
 import unittest
+from typing import Callable, Dict, Optional, List, Any
+from time import sleep
 from kubernetes import client, config
+from kubernetes.client import V1Secret
 from kubernetes.client.rest import ApiException
 
 # Load Kubernetes configuration from the default location or provide your own kubeconfig file path
@@ -15,12 +18,75 @@ CLUSTER_SECRET_NAMESPACE = "cluster-secret"
 USER_NAMESPACES = ["example-1", "example-2", "example-3"]
 
 
+def retry(f: Callable[[], bool], retries=3, delay=5):
+    while retries > 0:
+        if f():
+            return True
+        sleep(delay)
+        retries -= 1
+    return False
+
+
+def create_cluster_secret(
+        name: str,
+        namespace: str,
+        data: Dict[str, str],
+        labels: Optional[Dict[str, str]] = None,
+        annotations: Optional[Dict[str, str]] = None,
+        match_namespace: Optional[List[str]] = None,
+        avoid_namespaces: Optional[List[str]] = None,
+):
+    return custom_objects_api.create_namespaced_custom_object(
+        group="clustersecret.io",
+        version="v1",
+        namespace=namespace,
+        body={
+            "apiVersion": "clustersecret.io/v1",
+            "kind": "ClusterSecret",
+            "metadata": {"name": name, "labels": labels, "annotations": annotations},
+            "data": data,
+            "matchNamespace": match_namespace,
+            "avoidNamespaces": avoid_namespaces,
+        },
+        plural="clustersecrets",
+    )
+
+
+def update_data_cluster_secret(
+        name: str,
+        namespace: str,
+        data: Dict[str, str],
+):
+    custom_objects_api.patch_namespaced_custom_object(
+        name=name,
+        group="clustersecret.io",
+        version="v1",
+        namespace=namespace,
+        body={
+            "apiVersion": "clustersecret.io/v1",
+            "kind": "ClusterSecret",
+            "data": data,
+        },
+        plural="clustersecrets",
+    )
+
+
+def get_kubernetes_secret(name: str, namespace: str) -> Optional[V1Secret]:
+    try:
+        return api_instance.read_namespaced_secret(name, namespace)
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        else:
+            raise e
+
+
 class ClusterSecretCases(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        # First wait for the pod to be available
-        wait_for_pod_ready_with_events({'app': 'clustersecret'}, namespace='cluster-secret')
+        # Wait for the
+        wait_for_pod_ready_with_events({'app': 'clustersecret'}, namespace='cluster-secret', timeout_seconds=60)
 
         # Create namespaces for tests
         for namespace_name in USER_NAMESPACES:
@@ -40,23 +106,104 @@ class ClusterSecretCases(unittest.TestCase):
         self.assertEqual(len(pods.items), 1)
 
     def test_simple_cluster_secret(self):
-        custom_objects_api.create_namespaced_custom_object(
-            group="clustersecret.io",
-            version="v1",
+        name = "simple-cluster-secret"
+        username_data = "MTIzNDU2Cg=="
+
+        create_cluster_secret(name=name, namespace=USER_NAMESPACES[0], data={"username": username_data})
+
+        def validate():
+            for namespace in USER_NAMESPACES:
+                secret = get_kubernetes_secret(
+                    name=name,
+                    namespace=namespace
+                )
+
+                if secret is None:
+                    return False
+
+                self.assertEqual(secret.data['username'], username_data)
+
+            return True
+
+        self.assertTrue(retry(validate))
+
+    def test_complex_cluster_secret(self):
+        name = "complex-cluster-secret"
+        username_data = "MTIzNDU2Cg=="
+
+        create_cluster_secret(
+            name=name,
             namespace=USER_NAMESPACES[0],
-            body={
-                "apiVersion": "clustersecret.io/v1",
-                "kind": "ClusterSecret",
-                "metadata": {"name": "simple-cluster-secret"},
-                "data": {"username": "MTIzNDU2Cg=="}
-            },
-            plural="clustersecrets",
+            data={"username": username_data},
+            match_namespace=["example-*"],
+            avoid_namespaces=[USER_NAMESPACES[0]]
         )
 
-        secrets = api_instance.list_namespaced_secret(
-            namespace=USER_NAMESPACES[1]
-        )
-        self.assertEqual(len(secrets.items), 1)
+        # Ensure the secret is in all USER_NAMESPACES except the last one
+        def validate():
+            for namespace in USER_NAMESPACES[1:]:
+                secret = get_kubernetes_secret(
+                    name=name,
+                    namespace=namespace
+                )
+
+                if secret is None:
+                    return False
+
+                self.assertEqual(secret.data['username'], username_data)
+
+            secrets = api_instance.list_namespaced_secret(
+                namespace=USER_NAMESPACES[0]
+            )
+
+            self.assertEqual(len([secret for secret in secrets.items if secret.metadata.name == name]), 0)
+            return True
+
+        self.assertTrue(retry(validate))
+
+    def test_patch_cluster_secret(self):
+        name = "dynamic-cluster-secret"
+        username_data = "MTIzNDU2Cg=="
+        updated_data = "Nzg5MTAxMTIxMgo="
+
+        create_cluster_secret(name=name, namespace=USER_NAMESPACES[0], data={"username": username_data})
+
+        def validate():
+            for namespace in USER_NAMESPACES:
+                secret = get_kubernetes_secret(
+                    name=name,
+                    namespace=namespace
+                )
+
+                if secret is None:
+                    return False
+
+                self.assertEqual(secret.data['username'], username_data)
+
+            return True
+
+        self.assertTrue(retry(validate))
+
+        update_data_cluster_secret(name=name, data={"username": updated_data}, namespace=USER_NAMESPACES[0])
+
+        def validate():
+            for namespace in USER_NAMESPACES:
+                secret = get_kubernetes_secret(
+                    name=name,
+                    namespace=namespace
+                )
+
+                if secret.data['username'] != updated_data:
+                    return False
+
+            return True
+
+        self.assertTrue(retry(validate))
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # TODO: cleanup namespaces + ClusterSecrets
+        super().tearDownClass()
 
 
 if __name__ == '__main__':

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -1,0 +1,58 @@
+import unittest
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+# Load Kubernetes configuration from the default location or provide your own kubeconfig file path
+config.load_kube_config()
+
+# Create a Kubernetes API client
+api_instance = client.CoreV1Api()
+custom_objects_api = client.CustomObjectsApi()
+
+CLUSTER_SECRET_NAMESPACE = "cluster-secret"
+USER_NAMESPACES = ["example-1", "example-2", "example-3"]
+
+
+class ClusterSecretCases(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Create namespaces for tests
+        for namespace_name in USER_NAMESPACES:
+            namespace = client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace_name))
+            try:
+                api_instance.create_namespace(namespace)
+                print(f"Namespace '{namespace_name}' created successfully.")
+            except client.rest.ApiException as e:
+                if e.status == 409:
+                    print(f"Namespace '{namespace_name}' already exists.")
+                else:
+                    print(f"Error creating namespace '{namespace_name}': {e}")
+        super().setUpClass()
+
+    def test_running(self):
+        pods = api_instance.list_namespaced_pod(namespace=CLUSTER_SECRET_NAMESPACE)
+        self.assertEqual(len(pods.items), 1)
+
+    def test_simple_cluster_secret(self):
+        custom_objects_api.create_namespaced_custom_object(
+            group="clustersecret.io",
+            version="v1",
+            namespace=USER_NAMESPACES[0],
+            body={
+                "apiVersion": "clustersecret.io/v1",
+                "kind": "ClusterSecret",
+                "metadata": {"name": "simple-cluster-secret"},
+                "data": {"username": "MTIzNDU2Cg=="}
+            },
+            plural="clustersecrets",
+        )
+
+        secrets = api_instance.list_namespaced_secret(
+            namespace=USER_NAMESPACES[1]
+        )
+        self.assertEqual(len(secrets.items), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -172,6 +172,43 @@ class ClusterSecretCases(unittest.TestCase):
             f'secret {name} should be in all user namespaces'
         )
 
+    def test_simple_cluster_secret_deleted(self):
+        name = "simple-cluster-secret-deleted"
+        username_data = "MTIzNDU2Cg=="
+        cluster_secret_manager = ClusterSecretManager(
+            custom_objects_api=custom_objects_api,
+            api_instance=api_instance
+        )
+
+        cluster_secret_manager.create_cluster_secret(
+            name=name,
+            namespace=USER_NAMESPACES[0],
+            data={"username": username_data}
+        )
+
+        # We expect the secret to be in ALL namespaces
+        self.assertTrue(
+            cluster_secret_manager.validate_namespace_secrets(
+                name=name,
+                data={"username": username_data}
+            )
+        )
+
+        cluster_secret_manager.delete_cluster_secret(
+            name=name,
+            namespace=USER_NAMESPACES[0],
+        )
+
+        # We expect the secret to be in NO namespaces
+        self.assertTrue(
+            cluster_secret_manager.validate_namespace_secrets(
+                name=name,
+                data={"username": username_data},
+                namespaces=[],
+            ),
+            f'secret {name} should be deleted from all namespaces.'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -3,6 +3,8 @@ from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
 # Load Kubernetes configuration from the default location or provide your own kubeconfig file path
+from k8s_utils import wait_for_pod_ready_with_events
+
 config.load_kube_config()
 
 # Create a Kubernetes API client
@@ -17,6 +19,9 @@ class ClusterSecretCases(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        # First wait for the pod to be available
+        wait_for_pod_ready_with_events({'app': 'clustersecret'}, namespace='cluster-secret')
+
         # Create namespaces for tests
         for namespace_name in USER_NAMESPACES:
             namespace = client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace_name))


### PR DESCRIPTION
Adding e2e tests.

### Process 

The Github action added will:
- Build the Dockerfile and tag it `cluster-secret:COMMIT`
- Create a Kubernetes cluster using Kind
- Load the locally built docker image
- Lint the Helm chart
- Install the helm chart and set the image and tag to our locally loaded images
- Launch the conformance tests in `src/conformance/tests.py`

### Tests

The following tests are implemented

- [x] Deploying a ClusterSecret and ensuring Secrets are created in all namespace
- [x] Deploying a ClusterSecret with avoid and match namespace, and ensuring they are placed only where they are suppose to be.
- [x] Deploying a ClusterSecret and patching data, then ensuring the data is properly updated in all secrets.
- [x] Deploying a ClusterSecret and patching watchNamespace, then ensuring the secrets is propagated properly.
- [x] Deleting a ClusterSecret and ensuring the secrets are deleted.