### PR TITLE
feat: adding support for propagating annotations and labels

### DIFF
--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-secret
 description: ClusterSecret Operator
 kubeVersion: '>= 1.16.0-0'
 type: application
-version: 0.2.1
+version: 0.2.2
 icon: https://clustersecret.io/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret

--- a/charts/cluster-secret/templates/role-cluster-rbac.yaml
+++ b/charts/cluster-secret/templates/role-cluster-rbac.yaml
@@ -42,6 +42,7 @@ rules:
   - list
   - watch
   - patch
+  - get
 - apiGroups:
   - ""
   resources:

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -5,7 +5,7 @@ clustersecret:
       tag: 0.0.10
       # use tag-alt for ARM and other alternative builds - read the readme for more information
       # If Clustersecret is about to create a secret and then it founds it exists:
-      # Default is to ignore it. (to not loose any unintentional data) 
+      # Default is to ignore it. (to not loose any unintentional data)
       # It can also reeplace it. Just uncommenting next line.
-      #replace_existing: 'true'
+      # replace_existing: 'true'
 kubernetesClusterDomain: cluster.local

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -6,7 +6,10 @@ from kubernetes.client.rest import ApiException
 from time import sleep
 
 
-def is_subset(_set: Mapping[str, str], _subset: Mapping[str, str]) -> bool:
+def is_subset(_set: Optional[Mapping[str, str]], _subset: Optional[Mapping[str, str]]) -> bool:
+    if _set is None:
+        return _subset is None
+
     for key, item in _subset.items():
         if _set.get(key, None) != item:
             return False

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -269,7 +269,7 @@ class ClusterSecretCases(unittest.TestCase):
         )
 
     def test_simple_cluster_secret_with_annotation(self):
-        name = "simple-cluster-secret"
+        name = "simple-cluster-secret-annotation"
         username_data = "MTIzNDU2Cg=="
         annotations = {
             'custom-annotation': 'example',

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -268,6 +268,33 @@ class ClusterSecretCases(unittest.TestCase):
             msg=f'Cluster secret should take the data from the {secret_name} secret but only the keys specified.'
         )
 
+    def test_simple_cluster_secret_with_annotation(self):
+        name = "simple-cluster-secret"
+        username_data = "MTIzNDU2Cg=="
+        annotations = {
+            'custom-annotation': 'example',
+        }
+        cluster_secret_manager = ClusterSecretManager(
+            custom_objects_api=custom_objects_api,
+            api_instance=api_instance
+        )
+
+        cluster_secret_manager.create_cluster_secret(
+            name=name,
+            namespace=USER_NAMESPACES[0],
+            data={"username": username_data},
+            annotations=annotations,
+        )
+
+        # We expect the secret to be in ALL namespaces
+        self.assertTrue(
+            cluster_secret_manager.validate_namespace_secrets(
+                name=name,
+                data={"username": username_data},
+                annotations=annotations
+            )
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/consts.py
+++ b/src/consts.py
@@ -5,3 +5,5 @@ Constants used by the project
 CREATE_BY_ANNOTATION = 'clustersecret.io/created-by'
 LAST_SYNC_ANNOTATION = 'clustersecret.io/last-sync'
 VERSION_ANNOTATION = 'clustersecret.io/version'
+
+BLACK_LISTED_ANNOTATIONS = ["kopf.zalando.org", "kubectl.kubernetes.io"]

--- a/src/consts.py
+++ b/src/consts.py
@@ -3,7 +3,10 @@ Constants used by the project
 """
 
 CREATE_BY_ANNOTATION = 'clustersecret.io/created-by'
+CREATE_BY_AUTHOR = 'ClusterSecrets'
 LAST_SYNC_ANNOTATION = 'clustersecret.io/last-sync'
 VERSION_ANNOTATION = 'clustersecret.io/version'
+
+CLUSTER_SECRET_LABEL = "clustersecret.io"
 
 BLACK_LISTED_ANNOTATIONS = ["kopf.zalando.org", "kubectl.kubernetes.io"]

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -110,6 +110,7 @@ def on_field_data(
     old: Dict[str, str],
     new: Dict[str, str],
     body: Dict[str, Any],
+    meta: kopf.Meta,
     name: str,
     logger: logging.Logger,
     **_,
@@ -130,7 +131,12 @@ def on_field_data(
             api_version='v1',
             data=new,
             kind='Secret',
-            metadata=create_secret_metadata(name=name, namespace=ns),
+            metadata=create_secret_metadata(
+                name=name,
+                namespace=ns,
+                annotations=meta.annotations,
+                labels=meta.labels,
+            ),
             type=secret_type,
         )
         # Ensuring the secret still exist.

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -129,7 +129,7 @@ def on_field_data(
         logger.info(f'Re Syncing secret {name} in ns {ns}')
         body = client.V1Secret(
             api_version='v1',
-            data=new,
+            data=dict(new),
             kind='Secret',
             metadata=create_secret_metadata(
                 name=name,
@@ -243,5 +243,6 @@ async def startup_fn(logger: logging.Logger, **_):
                 name=metadata.get('name'),
                 namespace=metadata.get('namespace'),
                 data=item.get('data'),
+                synced_namespace=item.get('status', {}).get('create_fn', {}).get('syncedns', []),
             )
         )

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -123,7 +123,7 @@ def on_field_data(
     logger.debug(f'Updating Object body == {body}')
     syncedns = body.get('status', {}).get('create_fn', {}).get('syncedns', [])
 
-    secret_type = body.get('type', default='Opaque')
+    secret_type = body.get('type', 'Opaque')
 
     for ns in syncedns:
         logger.info(f'Re Syncing secret {name} in ns {ns}')

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -129,16 +129,17 @@ def on_field_data(
         logger.info(f'Re Syncing secret {name} in ns {ns}')
         body = client.V1Secret(
             api_version='v1',
-            data=dict(new),
+            data={str(key): str(value) for key, value in new.items()},
             kind='Secret',
             metadata=create_secret_metadata(
                 name=name,
                 namespace=ns,
-                annotations=meta.annotations,
-                labels=meta.labels,
+                annotations={str(key): str(value) for key, value in meta.annotations.items()},
+                labels={str(key): str(value) for key, value in meta.labels.items()},
             ),
             type=secret_type,
         )
+        logger.debug(f'body: {body}')
         # Ensuring the secret still exist.
         if secret_exists(logger=logger, name=name, namespace=ns, v1=v1):
             response = v1.replace_namespaced_secret(name=name, namespace=ns, body=body)

--- a/yaml/00_rbac.yaml
+++ b/yaml/00_rbac.yaml
@@ -33,7 +33,7 @@ rules:
   # Application: read-only access for watching cluster-wide.
   - apiGroups: [clustersecret.io]
     resources: [clustersecrets]
-    verbs: [list, watch, patch]
+    verbs: [list, watch, patch, get]
 
   # Watch namespaces
   - apiGroups: [""]


### PR DESCRIPTION
Fix: https://github.com/zakkg3/ClusterSecret/issues/80

## Descriptions

This will allows to propagate the labels and annotations of the ClusterSecret metadata to the generated secrets.

Global improvements on default annotations and labels

### e2e tests added

- [x] create a ClusterSecret with metadata `labels`, then ensuring secrets has
- [x] Create a ClusterSecret with metatdata `annotations`, then ensuring secrets has 