### PR TITLE
Add watch permission for customresourcedefinitions

### DIFF
--- a/charts/cluster-secret/templates/role-cluster-rbac.yaml
+++ b/charts/cluster-secret/templates/role-cluster-rbac.yaml
@@ -22,6 +22,7 @@ rules:
   - list
   - get
   - patch
+  - watch
 - apiGroups:
   - events.k8s.io
   resources:


### PR DESCRIPTION
This fixes the:
```
[2024-03-07 10:21:05,210] kopf._core.reactor.o [WARNING ] Not enough permissions to watch for resources: changes (creation/deletion/updates) will not be noticed; the resources are only refreshed on operator restarts.
```
We got the warning above using the helm chart 0.4.0. Adding this single permission seems to solve the problem.