### PR TITLE
Fix typo in Install instructions

### DIFF
--- a/charts/cluster-secret/README.md
+++ b/charts/cluster-secret/README.md
@@ -65,6 +65,6 @@ For older kubernes (<1.19) use the image tag "0.0.6" in  yaml/02_deployment.yaml
 ## Install
 
 ```bash
-helm repo add clutersecret https://charts.clustersecret.io/
+helm repo add clustersecret https://charts.clustersecret.io/
 helm install clustersecret clutersecret/clustersecret --version 0.4.0 -n clustersecret --create-namespace
 ```


### PR DESCRIPTION
There is a typo in the docs website for the installation instruction (which fails the install). It is not clear if the website takes directly from the code in this repo as the file structure is different from the READMEs here, but I found the same typo here. So here I make a PR to fix it.