### PR TITLE
feat: Add podAnnotations for deployment 

### DIFF
--- a/charts/cluster-secret/templates/deployment.yaml
+++ b/charts/cluster-secret/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         app: clustersecret
       {{- include "cluster-secret.selectorLabels" . | nindent 8 }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       securityContext:
         runAsUser: 100 # 100 is set by the container and can NOT be changed here - this would result in a getpwuid() error

--- a/charts/cluster-secret/templates/deployment.yaml
+++ b/charts/cluster-secret/templates/deployment.yaml
@@ -23,9 +23,9 @@ spec:
         app: clustersecret
       {{- include "cluster-secret.selectorLabels" . | nindent 8 }}
       annotations:
-{{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
         runAsUser: 100 # 100 is set by the container and can NOT be changed here - this would result in a getpwuid() error

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -15,3 +15,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional Pod annotations
+podAnnotations: {}


### PR DESCRIPTION
Added support for customizable pod annotations in the deployment.yaml and values.yaml files.

- Introduced a new `podAnnotations` field in values.yaml to allow users to define custom annotations for pods.
- Updated deployment.yaml to apply annotations from values.yaml using Helm's templating system.
- Removed redundant `end` statement in tolerations block for cleaner YAML structure.