### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -3,7 +3,7 @@ name: Build&Push Alt Images
 on:
   push:
     tags:
-      - '*'
+      - 'only-alts'
 #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
 #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
 
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y rustc
 
       - name: Build alt Images
         id: build_alt_image

--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -1,11 +1,11 @@
 # Docker build images on tag
 name: Build&Push Alt Images
-on:
-  push:
-    tags:
-      - 'only-alts'
-#          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-#          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+on: [push]
+#   push:
+#     tags:
+#       - 'only-alts'
+# #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+# #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
 
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
@@ -16,7 +16,7 @@ env:
 jobs:
   build-push-quay:
     name: Build&Push Alt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
       # matrix:
@@ -45,7 +45,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: alt-${{ env.IMAGE_TAGS }}
-          platforms: linux/s390x, linux/arm/v5, linux/arm/v7, linux/arm64/v8 #, linux/mips64le, linux/ppc64le, 
+          platforms: linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
           containerfiles: |
             ./Dockerfile-others.gh
 

--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAMESPACE : clustersecret
 
 jobs:
-  build-push-quay:
+  build-push-quay-v5:
     name: Build&Push Alt
     runs-on: ubuntu-24.04
     # strategy:
@@ -49,6 +49,31 @@ jobs:
           containerfiles: |
             ./Dockerfile-others.gh
 
+  build-push-quay-s390:
+    name: Build&Push Alt
+    runs-on: ubuntu-24.04
+    # strategy:
+    #   fail-fast: false
+      # matrix:
+        # install_latest: [ true, false ] #ubuntu-20.04 has a good enough podman.
+    steps:
+      # Checkout push-to-registry action github repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v2
+
+      # - name: Install latest podman
+      #   if: matrix.install_latest
+      #   run: |
+      #     bash .github/install_latest_podman.sh
+
+      - name: Install qemu dependency
+        # we need quemu-user-static for builds other archs with buildah
+        # https://github.com/containers/podman/issues/13924#issuecomment-1103434554
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y rustc
+
       - name: Build alt Image s390
         id: build_alt_image390
         uses: redhat-actions/buildah-build@main
@@ -59,6 +84,31 @@ jobs:
           containerfiles: |
             ./Dockerfile-others.gh
 
+  build-push-quay-armv8:
+    name: Build&Push Alt
+    runs-on: ubuntu-24.04
+    # strategy:
+    #   fail-fast: false
+      # matrix:
+        # install_latest: [ true, false ] #ubuntu-20.04 has a good enough podman.
+    steps:
+      # Checkout push-to-registry action github repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v2
+
+      # - name: Install latest podman
+      #   if: matrix.install_latest
+      #   run: |
+      #     bash .github/install_latest_podman.sh
+
+      - name: Install qemu dependency
+        # we need quemu-user-static for builds other archs with buildah
+        # https://github.com/containers/podman/issues/13924#issuecomment-1103434554
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y rustc
+
       - name: Build alt Image armv8
         id: build_alt_imagev8
         uses: redhat-actions/buildah-build@main
@@ -68,6 +118,31 @@ jobs:
           platforms: linux/arm64/v8
           containerfiles: |
             ./Dockerfile-others.gh
+
+  build-push-quay-armv7:
+    name: Build&Push Alt
+    runs-on: ubuntu-24.04
+    # strategy:
+    #   fail-fast: false
+      # matrix:
+        # install_latest: [ true, false ] #ubuntu-20.04 has a good enough podman.
+    steps:
+      # Checkout push-to-registry action github repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v2
+
+      # - name: Install latest podman
+      #   if: matrix.install_latest
+      #   run: |
+      #     bash .github/install_latest_podman.sh
+
+      - name: Install qemu dependency
+        # we need quemu-user-static for builds other archs with buildah
+        # https://github.com/containers/podman/issues/13924#issuecomment-1103434554
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y rustc
 
       - name: Build alt Image armv7
         id: build_alt_imagev7

--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -1,11 +1,11 @@
 # Docker build images on tag
 name: Build&Push Alt Images
-on: [push]
-#   push:
-#     tags:
-#       - 'only-alts'
-# #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-# #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+on:
+  push:
+    tags:
+      - 'test-alts'
+#          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+#          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
 
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
@@ -39,15 +39,15 @@ jobs:
           sudo apt-get install -y qemu-user-static
           sudo apt-get install -y rustc
 
-      - name: Build alt Image armv5
-        id: build_alt_imagev5
-        uses: redhat-actions/buildah-build@main
-        with:
-          image: ${{ env.IMAGE_NAMESPACE }}
-          tags: alt-${{ env.IMAGE_TAGS }}
-          platforms: linux/arm/v5
-          containerfiles: |
-            ./Dockerfile-others.gh
+      # - name: Build alt Image armv5 # not working 
+      #   id: build_alt_imagev5
+      #   uses: redhat-actions/buildah-build@main
+      #   with:
+      #     image: ${{ env.IMAGE_NAMESPACE }}
+      #     tags: alt-${{ env.IMAGE_TAGS }}
+      #     platforms: linux/arm/v5
+      #     containerfiles: |
+      #       ./Dockerfile-others.gh
 
   build-push-quay-s390:
     name: Build&Push Alt
@@ -155,16 +155,16 @@ jobs:
             ./Dockerfile-others.gh
 
       # Push the image manifest to Quay.io (Image Registry)
-      - name: Push To Quay
-        # uses: ./
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build_alt_image.outputs.image }}
-          tags: ${{ steps.build_alt_image.outputs.tags }}
-          registry: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+      # - name: Push To Quay
+      #   # uses: ./
+      #   id: push-to-quay
+      #   uses: redhat-actions/push-to-registry@v2
+      #   with:
+      #     image: ${{ steps.build_alt_image.outputs.image }}
+      #     tags: ${{ steps.build_alt_image.outputs.tags }}
+      #     registry: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}
+      #     username: ${{ secrets.REGISTRY_USER }}
+      #     password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Echo outputs
         run: |

--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install -y rustc
 
       - name: Build alt Image armv5
-        id: build_alt_image
+        id: build_alt_imagev5
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
@@ -50,7 +50,7 @@ jobs:
             ./Dockerfile-others.gh
 
       - name: Build alt Image s390
-        id: build_alt_image
+        id: build_alt_image390
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
@@ -60,7 +60,7 @@ jobs:
             ./Dockerfile-others.gh
 
       - name: Build alt Image armv8
-        id: build_alt_image
+        id: build_alt_imagev8
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
@@ -70,7 +70,7 @@ jobs:
             ./Dockerfile-others.gh
 
       - name: Build alt Image armv7
-        id: build_alt_image
+        id: build_alt_imagev7
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}

--- a/.github/workflows/build-alt.yaml
+++ b/.github/workflows/build-alt.yaml
@@ -39,13 +39,43 @@ jobs:
           sudo apt-get install -y qemu-user-static
           sudo apt-get install -y rustc
 
-      - name: Build alt Images
+      - name: Build alt Image armv5
         id: build_alt_image
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: alt-${{ env.IMAGE_TAGS }}
-          platforms: linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
+          platforms: linux/arm/v5
+          containerfiles: |
+            ./Dockerfile-others.gh
+
+      - name: Build alt Image s390
+        id: build_alt_image
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: ${{ env.IMAGE_NAMESPACE }}
+          tags: alt-${{ env.IMAGE_TAGS }}
+          platforms: linux/s390x
+          containerfiles: |
+            ./Dockerfile-others.gh
+
+      - name: Build alt Image armv8
+        id: build_alt_image
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: ${{ env.IMAGE_NAMESPACE }}
+          tags: alt-${{ env.IMAGE_TAGS }}
+          platforms: linux/arm64/v8
+          containerfiles: |
+            ./Dockerfile-others.gh
+
+      - name: Build alt Image armv7
+        id: build_alt_image
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: ${{ env.IMAGE_NAMESPACE }}
+          tags: alt-${{ env.IMAGE_TAGS }}
+          platforms: linux/arm/v7
           containerfiles: |
             ./Dockerfile-others.gh
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }}
-          platforms: llinux/amd64
+          platforms: linux/amd64
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -167,7 +167,7 @@ jobs:
           echo "${{ toJSON(steps.push-to-quay.outputs) }}"
 
   build-armv7:
-    name: Build armv7
+    name: Build armv7 #note it needs build essentials (uses docker-others)
     runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,11 +1,6 @@
 # Docker build images on tag
-name: Build&Push Alt Images
-on:
-  push:
-    tags:
-      - 'test-alts'
-#          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-#          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+name: BuildAlt Images
+on: [pull_request]
 
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
@@ -14,8 +9,8 @@ env:
   IMAGE_NAMESPACE : clustersecret
 
 jobs:
-  build-push-quay-v5:
-    name: Build&Push Alt
+  build-amd64:
+    name: Build amd64
     runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
@@ -37,20 +32,63 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-          sudo apt-get install -y rustc
 
-      # - name: Build alt Image armv5 # not working 
-      #   id: build_alt_imagev5
-      #   uses: redhat-actions/buildah-build@main
-      #   with:
-      #     image: ${{ env.IMAGE_NAMESPACE }}
-      #     tags: alt-${{ env.IMAGE_TAGS }}
-      #     platforms: linux/arm/v5
-      #     containerfiles: |
-      #       ./Dockerfile-others.gh
+      - name: Build amd64
+        id: build_image386
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: ${{ env.IMAGE_NAMESPACE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          platforms: llinux/amd64
+          containerfiles: |
+            ./Dockerfile.gh
 
-  build-push-quay-s390:
-    name: Build&Push Alt
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push-to-quay.outputs) }}"
+
+
+  build-386:
+    name: Build 386
+    runs-on: ubuntu-24.04
+    # strategy:
+    #   fail-fast: false
+      # matrix:
+        # install_latest: [ true, false ] #ubuntu-20.04 has a good enough podman.
+    steps:
+      # Checkout push-to-registry action github repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v2
+
+      # - name: Install latest podman
+      #   if: matrix.install_latest
+      #   run: |
+      #     bash .github/install_latest_podman.sh
+
+      - name: Install qemu dependency
+        # we need quemu-user-static for builds other archs with buildah
+        # https://github.com/containers/podman/issues/13924#issuecomment-1103434554
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build alt Image 386
+        id: build_image386
+        uses: redhat-actions/buildah-build@main
+        with:
+          image: ${{ env.IMAGE_NAMESPACE }}
+          tags: ${{ env.IMAGE_TAGS }}
+          platforms: linux/386
+          containerfiles: |
+            ./Dockerfile.gh
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push-to-quay.outputs) }}"
+
+
+  build-s390:
+    name: Builds 390
     runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
@@ -75,17 +113,22 @@ jobs:
           sudo apt-get install -y rustc
 
       - name: Build alt Image s390
-        id: build_alt_image390
+        id: build_image390
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
-          tags: alt-${{ env.IMAGE_TAGS }}
+          tags: ${{ env.IMAGE_TAGS }}
           platforms: linux/s390x
           containerfiles: |
-            ./Dockerfile-others.gh
+            ./Dockerfile.gh
 
-  build-push-quay-armv8:
-    name: Build&Push Alt
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push-to-quay.outputs) }}"
+
+
+  build-armv8:
+    name: Build armv8
     runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
@@ -114,13 +157,17 @@ jobs:
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
-          tags: alt-${{ env.IMAGE_TAGS }}
+          tags: ${{ env.IMAGE_TAGS }}
           platforms: linux/arm64/v8
           containerfiles: |
-            ./Dockerfile-others.gh
+            ./Dockerfile.gh
 
-  build-push-quay-armv7:
-    name: Build&Push Alt
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push-to-quay.outputs) }}"
+
+  build-armv7:
+    name: Build armv7
     runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
@@ -149,22 +196,10 @@ jobs:
         uses: redhat-actions/buildah-build@main
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
-          tags: alt-${{ env.IMAGE_TAGS }}
+          tags: ${{ env.IMAGE_TAGS }}
           platforms: linux/arm/v7
           containerfiles: |
-            ./Dockerfile-others.gh
-
-      # Push the image manifest to Quay.io (Image Registry)
-      # - name: Push To Quay
-      #   # uses: ./
-      #   id: push-to-quay
-      #   uses: redhat-actions/push-to-registry@v2
-      #   with:
-      #     image: ${{ steps.build_alt_image.outputs.image }}
-      #     tags: ${{ steps.build_alt_image.outputs.tags }}
-      #     registry: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}
-      #     username: ${{ secrets.REGISTRY_USER }}
-      #     password: ${{ secrets.REGISTRY_PASSWORD }}
+            ./Dockerfile.gh
 
       - name: Echo outputs
         run: |

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,5 +1,5 @@
 # Docker build images on tag
-name: BuildAlt Images
+name: Test Builds Images
 on: [pull_request]
 
 env:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -199,7 +199,7 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           platforms: linux/arm/v7
           containerfiles: |
-            ./Dockerfile.gh
+            ./Dockerfile-others.gh
 
       - name: Echo outputs
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64, linux/s390x, linux/arm64/v8, linux/arm/v7
+          platforms: linux/386, linux/amd64, linux/s390x, linux/arm64/v8
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,9 @@ on:
       - '*'
 #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
 #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
-
+  pull_request:
+    types:
+      - opened
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
   REGISTRY_USER: clustersecret

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
+          sudo apt-get install -y rustc
 
       - name: Build Image
         id: build_image
@@ -44,7 +45,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8
+          platforms: linux/386, linux/amd64
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64
+          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,7 @@ on:
       - '*'
 #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
 #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
-  pull_request:
-    types:
-      - opened
+
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
   REGISTRY_USER: clustersecret

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,11 @@
 # Docker build images on tag
 name: Build&Push Images
-on: [push]
-
-#   push:
-#     tags:
-#       - '*'
-# #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-# #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+on:
+  push:
+    tags:
+      - '*'
+#          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+#          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
 
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
@@ -45,7 +44,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64
+          platforms: linux/386, linux/amd64, linux/s390x, linux/arm64/v8, linux/arm/v7
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
+          platforms: linux/386, linux/amd64
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,12 @@
 # Docker build images on tag
 name: Build&Push Images
-on:
-  push:
-    tags:
-      - '*'
-#          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-#          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+on: [push]
+
+#   push:
+#     tags:
+#       - '*'
+# #          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+# #          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
 
 env:
   IMAGE_TAGS: ${{  github.ref_name }}
@@ -45,7 +46,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
+          platforms: linux/386, linux/amd64, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build-push-quay:
     name: Build&Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # strategy:
     #   fail-fast: false
       # matrix:
@@ -38,7 +38,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-          sudo apt-get install -y rustc
 
       - name: Build Image
         id: build_image
@@ -46,7 +45,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAMESPACE }}
           tags: ${{ env.IMAGE_TAGS }} latest
-          platforms: linux/386, linux/amd64, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
+          platforms: linux/386, linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/s390x #, linux/mips64le, linux/ppc64le, 
           containerfiles: |
             ./Dockerfile.gh
 

--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -1,6 +1,6 @@
 name: E2E Testing
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   e2e-tests:

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10","3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
 kopf===1.37.2
 kubernetes===19.15.0
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
-pydantic==2.4.0
+pydantic==2.3.0


### PR DESCRIPTION
work in progress 
fix build image "cant find rust compiler" when installing pedantic

some here https://github.com/termux/termux-app/discussions/3860



```
        × Building wheel for maturin (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [28 lines of output]
            running bdist_wheel
            running build
            running build_py
            creating build/lib.linux-armv7l-cpython-39/maturin
            copying maturin/__init__.py -> build/lib.linux-armv7l-cpython-39/maturin
            copying maturin/__main__.py -> build/lib.linux-armv7l-cpython-39/maturin
            running egg_info
            writing maturin.egg-info/PKG-INFO
            writing dependency_links to maturin.egg-info/dependency_links.txt
            writing requirements to maturin.egg-info/requires.txt
            writing top-level names to maturin.egg-info/top_level.txt
            reading manifest file 'maturin.egg-info/SOURCES.txt'
            reading manifest template 'MANIFEST.in'
            warning: no files found matching '*.json' under directory 'src/python_interpreter'
            writing manifest file 'maturin.egg-info/SOURCES.txt'
            running build_ext
            running build_rust
            error: can't find Rust compiler
```