### PR TITLE
expose the default value for replace_existing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMG_NAMESPACE = flag5
 IMG_NAME = clustersecret
 IMG_FQNAME = $(IMG_NAMESPACE)/$(IMG_NAME)
-IMG_VERSION = 0.0.11
+IMG_VERSION = 0.0.12
 
 .PHONY: container push clean 
 all: container

--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.4.4
 icon: https://clustersecret.com/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret
-appVersion: "0.0.11"
+appVersion: "0.0.12"
 maintainers:
 - email: zakkg3@gmail.com
   name: zakkg3

--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-secret
 description: ClusterSecret Operator
 kubeVersion: '>= 1.25.0-0'
 type: application
-version: 0.4.3
+version: 0.4.4
 icon: https://clustersecret.com/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret

--- a/charts/cluster-secret/README.md
+++ b/charts/cluster-secret/README.md
@@ -57,7 +57,7 @@ Clustersecrets automates this. It keep track of any modification in your secret 
 
 ## Requirements
 
-Current is 0.0.11 tested on > 1.27.1
+Current is 0.0.12 tested on > 1.27.1
 Version 0.0.9 is tested for Kubernetes >= 1.19 up to 1.27.1
 
 For older kubernes (<1.19) use the image tag "0.0.6" in  yaml/02_deployment.yaml

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -1,7 +1,7 @@
 imagePullSecrets: []
 image:
   repository: quay.io/clustersecret/clustersecret
-  tag: 0.0.11
+  tag: 0.0.12
   # use tag-alt for ARM and other alternative builds - read the readme for more information
   # If Clustersecret is about to create a secret and then it founds it exists:
   # Default is to ignore it via false setting. (to not loose any unintentional data)

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -4,9 +4,9 @@ image:
   tag: 0.0.11
   # use tag-alt for ARM and other alternative builds - read the readme for more information
   # If Clustersecret is about to create a secret and then it founds it exists:
-  # Default is to ignore it. (to not loose any unintentional data)
-  # It can also reeplace it. Just uncommenting next line.
-  # replace_existing: 'true'
+  # Default is to ignore it via false setting. (to not loose any unintentional data)
+  # It can also be replaced, just set value to true.
+  replace_existing: 'false'
 kubernetesClusterDomain: cluster.local
 
 


### PR DESCRIPTION
It wasn't apparent to me that the [replace_existing](https://clustersecret.com/config/#replace_exisiting) parameter was available until I reviewed the documentation. This is mostly because I converted the helm chart to be a flux helmRelease which doesn't translate the comments to the artifact for flux's helm-controller. My thought was rather than uncomment the lines in the value just show it with its default of false and that way users can just change the value in the chart to override.

For example with flux creation
```c
flux create hr cluster-secret --target-namespace=clustersecret --source=HelmRepository/cluster-secret --chart=cluster-secret --values=./values.yaml --export > helmrelease-cluster-secret.yaml
```
viewing the artifiact below that the helm-controller will use you can see that its not immediately apparent that **replace_existing** value is even used.
```c
cat helmrelease-cluster-secret.yaml 
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  name: cluster-secret
  namespace: flux-system
spec:
  chart:
    spec:
      chart: cluster-secret
      reconcileStrategy: ChartVersion
      sourceRef:
        kind: HelmRepository
        name: cluster-secret
  interval: 1m0s
  targetNamespace: clustersecret
  values:
    affinity: {}
    image:
      repository: quay.io/clustersecret/clustersecret
      tag: 0.0.11
    imagePullSecrets: []
    kubernetesClusterDomain: cluster.local
    nodeSelector: {}
    podAnnotations: {}
    tolerations: []
```
