### PR TITLE
feat: allow to customize the blocked labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMG_NAMESPACE = flag5
 IMG_NAME = clustersecret
 IMG_FQNAME = $(IMG_NAMESPACE)/$(IMG_NAME)
-IMG_VERSION = 0.0.12
+IMG_VERSION = 0.0.13
 
 .PHONY: container push clean 
 all: container

--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -3,11 +3,11 @@ name: cluster-secret
 description: ClusterSecret Operator
 kubeVersion: '>= 1.25.0-0'
 type: application
-version: 0.4.4
+version: 0.5.0
 icon: https://clustersecret.com/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret
-appVersion: "0.0.12"
+appVersion: "0.0.13"
 maintainers:
 - email: zakkg3@gmail.com
   name: zakkg3

--- a/charts/cluster-secret/templates/deployment.yaml
+++ b/charts/cluster-secret/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
       - env:
-        {{- .Values.env | default [] | toYAML | nindent 8 }}
+        {{- .Values.env | toYaml | nindent 8 }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
         - name: CLUSTER_SECRET_VERSION

--- a/charts/cluster-secret/templates/deployment.yaml
+++ b/charts/cluster-secret/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
       {{- end }}
       containers:
       - env:
+        {{- .Values.env | default [] | toYAML | nindent 8 }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
         - name: CLUSTER_SECRET_VERSION

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -10,7 +10,7 @@ image:
 
 env:
   - name: BLOCKED_LABELS
-    value: app.kubernetes.io # it's a comma (,) separated list
+    value: app.kubernetes.io  # a comma (,) separated list
 
 kubernetesClusterDomain: cluster.local
 

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -7,6 +7,11 @@ image:
   # Default is to ignore it via false setting. (to not loose any unintentional data)
   # It can also be replaced, just set value to true.
   replace_existing: 'false'
+
+env:
+  - name: BLOCKED_LABELS
+    value: app.kubernetes.io # it's a comma (,) separated list
+
 kubernetesClusterDomain: cluster.local
 
 

--- a/src/consts.py
+++ b/src/consts.py
@@ -9,5 +9,6 @@ VERSION_ANNOTATION = 'clustersecret.io/version'
 
 CLUSTER_SECRET_LABEL = "clustersecret.io"
 
-BLACK_LISTED_ANNOTATIONS = ["kopf.zalando.org", "kubectl.kubernetes.io"]
-BLACK_LISTED_LABELS = ["app.kubernetes.io"]
+BLOCKED_ANNOTATIONS = ["kopf.zalando.org", "kubectl.kubernetes.io"]
+
+BLOCKED_LABELS = ["app.kubernetes.io"]

--- a/src/kubernetes_utils.py
+++ b/src/kubernetes_utils.py
@@ -6,9 +6,9 @@ import re
 import kopf
 from kubernetes.client import CoreV1Api, CustomObjectsApi, exceptions, V1ObjectMeta, rest, V1Secret
 
-from os_utils import get_replace_existing, get_version
-from consts import CREATE_BY_ANNOTATION, LAST_SYNC_ANNOTATION, VERSION_ANNOTATION, BLACK_LISTED_ANNOTATIONS, \
-    BLACK_LISTED_LABELS, CREATE_BY_AUTHOR, CLUSTER_SECRET_LABEL
+from os_utils import get_blocked_labels, get_replace_existing, get_version
+from consts import CREATE_BY_ANNOTATION, LAST_SYNC_ANNOTATION, VERSION_ANNOTATION, BLOCKED_ANNOTATIONS, \
+    CREATE_BY_AUTHOR, CLUSTER_SECRET_LABEL
 
 
 def patch_clustersecret_status(
@@ -309,8 +309,8 @@ def create_secret_metadata(
         LAST_SYNC_ANNOTATION: datetime.now().isoformat(),
     }
 
-    _annotations = filter_dict(BLACK_LISTED_ANNOTATIONS, base_annotations, annotations)
-    _labels = filter_dict(BLACK_LISTED_LABELS, base_labels, labels)
+    _annotations = filter_dict(BLOCKED_ANNOTATIONS, base_annotations, annotations)
+    _labels = filter_dict(get_blocked_labels(), base_labels, labels)
     return V1ObjectMeta(
         name=name,
         namespace=namespace,

--- a/src/os_utils.py
+++ b/src/os_utils.py
@@ -20,12 +20,11 @@ def get_replace_existing() -> bool:
 
 @cache
 def get_blocked_labels() -> list[str]:
-    blocked_labels = os.getenv('BLOCKED_LABELS')
+    if blocked_labels := os.getenv('BLOCKED_LABELS'):
+        return [label.strip() for label in blocked_labels.split(',')]
 
-    if not blocked_labels:
-        return BLOCKED_LABELS
+    return BLOCKED_LABELS
 
-    return [label.strip() for label in blocked_labels.split(',')]
 
 @cache
 def in_cluster() -> bool:

--- a/src/os_utils.py
+++ b/src/os_utils.py
@@ -20,9 +20,12 @@ def get_replace_existing() -> bool:
 
 @cache
 def get_blocked_labels() -> list[str]:
-    blocked_labels = os.getenv('BLOCKED_LABELS', ','.join(BLOCKED_LABELS))
-    return [label.strip() for label in blocked_labels.split(',')]
+    blocked_labels = os.getenv('BLOCKED_LABELS')
 
+    if not blocked_labels:
+        return BLOCKED_LABELS
+
+    return [label.strip() for label in blocked_labels.split(',')]
 
 @cache
 def in_cluster() -> bool:

--- a/src/os_utils.py
+++ b/src/os_utils.py
@@ -1,6 +1,10 @@
 import os
+from functools import cache
+
+from consts import BLOCKED_LABELS
 
 
+@cache
 def get_version() -> str:
     """
     Wrapper for CLUSTER_SECRET_VERSION variable environment
@@ -8,12 +12,19 @@ def get_version() -> str:
     return os.getenv('CLUSTER_SECRET_VERSION', '0')
 
 
+@cache
 def get_replace_existing() -> bool:
-
     replace_existing = os.getenv('REPLACE_EXISTING', 'false')
     return replace_existing.lower() == 'true'
 
 
+@cache
+def get_blocked_labels() -> list[str]:
+    blocked_labels = os.getenv('BLOCKED_LABELS', ','.join(BLOCKED_LABELS))
+    return [label.strip() for label in blocked_labels.split(',')]
+
+
+@cache
 def in_cluster() -> bool:
     """
     Whether we are running in cluster (on the pod)  or outside (debug mode.)

--- a/src/tests/test_kubernetes_utils.py
+++ b/src/tests/test_kubernetes_utils.py
@@ -99,7 +99,7 @@ class TestClusterSecret(unittest.TestCase):
             (LAST_SYNC_ANNOTATION, is_iso_format)
         ]
 
-        attributes_black_lists = dict(
+        attributes_blocked_lists = dict(
             labels=get_blocked_labels(),
             annotations=BLOCKED_ANNOTATIONS,
         )
@@ -140,15 +140,15 @@ class TestClusterSecret(unittest.TestCase):
 
             self.assertIsInstance(obj=subject, cls=V1ObjectMeta, msg='returned value has correct type')
 
-            for attribute, black_list in attributes_black_lists.items():
+            for attribute, blocked_list in attributes_blocked_lists.items():
                 attribute_object = subject.__getattribute__(attribute)
                 self.assertIsNotNone(obj=attribute_object, msg=f'attribute "{attribute}" is not None')
 
                 for key in attribute_object.keys():
                     self.assertIsInstance(obj=key, cls=str, msg=f'the {attribute} key is a string')
-                    for black_listed_label_prefix in black_list:
+                    for blocked_listed_label_prefix in blocked_list:
                         self.assertFalse(
-                            expr=key.startswith(black_listed_label_prefix),
+                            expr=key.startswith(blocked_listed_label_prefix),
                             msg=f'{attribute} key does not match black listed prefix'
                         )
 

--- a/src/tests/test_kubernetes_utils.py
+++ b/src/tests/test_kubernetes_utils.py
@@ -6,10 +6,10 @@ from unittest.mock import Mock
 
 from kubernetes.client import V1ObjectMeta
 
-from consts import CREATE_BY_ANNOTATION, LAST_SYNC_ANNOTATION, VERSION_ANNOTATION, BLACK_LISTED_ANNOTATIONS, \
-    BLACK_LISTED_LABELS, CREATE_BY_AUTHOR, CLUSTER_SECRET_LABEL
+from consts import CREATE_BY_ANNOTATION, LAST_SYNC_ANNOTATION, VERSION_ANNOTATION, BLOCKED_ANNOTATIONS, \
+    CREATE_BY_AUTHOR, CLUSTER_SECRET_LABEL
 from kubernetes_utils import get_ns_list, create_secret_metadata
-from os_utils import get_version
+from os_utils import get_version, get_blocked_labels
 
 USER_NAMESPACE_COUNT = 10
 initial_namespaces = ['default', 'kube-node-lease', 'kube-public', 'kube-system']
@@ -100,8 +100,8 @@ class TestClusterSecret(unittest.TestCase):
         ]
 
         attributes_black_lists = dict(
-            labels=BLACK_LISTED_LABELS,
-            annotations=BLACK_LISTED_ANNOTATIONS,
+            labels=get_blocked_labels(),
+            annotations=BLOCKED_ANNOTATIONS,
         )
 
         test_cases: list[Tuple[dict[str, str], dict[str, str]]] = [


### PR DESCRIPTION
See #150.

In short, recent ArgoCD Helm charts are not using app.kubernetes.io/instance but something else, which can be changed. This opens the door to tweaking the values via the chart.