### PR TITLE
remove references to clustersecret resource namespace

### DIFF
--- a/conformance/cluster-secrets.yaml
+++ b/conformance/cluster-secrets.yaml
@@ -2,7 +2,6 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 data:
   username: MTIzNDU2Cg==
   password: MTIzNDU2Cg==
@@ -11,7 +10,6 @@ kind: ClusterSecret
 apiVersion: clustersecret.io/v1
 metadata:
   name: typed-secret
-  namespace: example-1
   type: kubernetes.io/tls
 data:
   tls.crt: MTIzNDU2Cg==
@@ -21,7 +19,6 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 avoidNamespaces:
   - example-3
 ---

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -153,8 +153,7 @@ class ClusterSecretManager:
 
     def delete_cluster_secret(
             self,
-            name: str,
-            namespace: str
+            name: str
     ):
         self.custom_objects_api.delete_cluster_custom_object(
             name=name,

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -181,7 +181,6 @@ class ClusterSecretCases(unittest.TestCase):
 
         self.cluster_secret_manager.delete_cluster_secret(
             name=name,
-            namespace=USER_NAMESPACES[0],
         )
 
         # We expect the secret to be in NO namespaces
@@ -212,7 +211,6 @@ class ClusterSecretCases(unittest.TestCase):
             name=cluster_secret_name,
             secret_key_ref={
                 'name': secret_name,
-                'namespace': USER_NAMESPACES[0],
             },
         )
 
@@ -245,7 +243,6 @@ class ClusterSecretCases(unittest.TestCase):
             name=cluster_secret_name,
             secret_key_ref={
                 'name': secret_name,
-                'namespace': USER_NAMESPACES[0],
                 'keys': ['username', 'password']
             },
         )

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -118,8 +118,6 @@ def on_field_data(
     logger: logging.Logger,
     **_,
 ):
-    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
-
     logger.debug(f'Data changed: {old} -> {new}')
     if old is None:
         logger.debug('This is a new object: Ignoring')
@@ -134,7 +132,6 @@ def on_field_data(
     if cached_cluster_secret is None:
         logger.error('Received an event for an unknown ClusterSecret.')
 
-    updated_syncedns = syncedns.copy()
     for ns in syncedns:
         logger.info(f'Re Syncing secret {name} in ns {ns}')
         sync_secret(logger, ns, body, v1)

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -60,8 +60,6 @@ def on_field_match_namespace(
     logger: logging.Logger,
     **_,
 ):
-    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
-
     logger.debug(f'Namespaces changed: {old} -> {new}')
 
     if old is None:
@@ -92,7 +90,6 @@ def on_field_match_namespace(
     csecs_cache.set_cluster_secret(BaseClusterSecret(
         uid=uid,
         name=name,
-        namespace=namespace,
         body=body,
         synced_namespace=updated_matched,
     ))
@@ -148,7 +145,6 @@ async def create_fn(
 ):
     # get all ns matching.
     matchedns = get_ns_list(logger, body, v1)
-    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
 
     # sync in all matched NS
     logger.info(f'Syncing on Namespaces: {matchedns}')
@@ -164,7 +160,6 @@ async def create_fn(
     csecs_cache.set_cluster_secret(BaseClusterSecret(
         uid=uid,
         name=name,
-        namespace=namespace or "",
         body=body,
         synced_namespace=matchedns,
     ))
@@ -236,7 +231,6 @@ async def startup_fn(logger: logging.Logger, **_):
             BaseClusterSecret(
                 uid=metadata.get('uid'),
                 name=metadata.get('name'),
-                namespace=metadata.get('namespace', ''),
                 body=item,
                 synced_namespace=item.get('status', {}).get('create_fn', {}).get('syncedns', []),
             )

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -133,6 +133,14 @@ def on_field_data(
         logger.info(f'Re Syncing secret {name} in ns {ns}')
         sync_secret(logger, ns, body, v1)
 
+    # Updating the cache
+    csecs_cache.set_cluster_secret(BaseClusterSecret(
+        uid=uid,
+        name=name,
+        body=body,
+        synced_namespace=syncedns,
+    ))
+
 
 @kopf.on.resume('clustersecret.io', 'v1', 'clustersecrets')
 @kopf.on.create('clustersecret.io', 'v1', 'clustersecrets')

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,5 @@ from pydantic import BaseModel
 class BaseClusterSecret(BaseModel):
     uid: str
     name: str
-    namespace: str
     body: Dict[str, Any]
     synced_namespace: List[str]


### PR DESCRIPTION
The clustersecret resource was changed to cluster scope, but the BaseClusterSecret model still includes a namespace string.  All namespace references are removed.

In the case of on_field_data the namespace is removed and secret creation is handed off to the sync_secret function.