### PR TITLE
Removing unnecessary 'namespace' references to clear code and resolve error log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+conformance/__pycache__/
 src/__pycache__/
 src/tests/__pycache__/
 yaml/Object_example/debug-*

--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -3,11 +3,11 @@ name: cluster-secret
 description: ClusterSecret Operator
 kubeVersion: '>= 1.25.0-0'
 type: application
-version: 0.5.0
+version: 0.5.1
 icon: https://clustersecret.com/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret
-appVersion: "0.0.13"
+appVersion: "0.0.14"
 maintainers:
 - email: zakkg3@gmail.com
   name: zakkg3

--- a/charts/cluster-secret/README.md
+++ b/charts/cluster-secret/README.md
@@ -18,7 +18,6 @@ Here is how it looks like:
 kind: ClusterSecret
 apiVersion: clustersecret.io/v1
 metadata:
-  namespace: clustersecret
   name: default-wildcard-certifiate
 matchNamespace:
   - prefix_ns-*

--- a/conformance/cluster-secrets.yaml
+++ b/conformance/cluster-secrets.yaml
@@ -2,16 +2,14 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 data:
   username: MTIzNDU2Cg==
   password: MTIzNDU2Cg==
 ---
-kind: ClusterSecret
 apiVersion: clustersecret.io/v1
+kind: ClusterSecret
 metadata:
   name: typed-secret
-  namespace: example-1
   type: kubernetes.io/tls
 data:
   tls.crt: MTIzNDU2Cg==
@@ -21,7 +19,6 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 avoidNamespaces:
   - example-3
 ---

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -153,8 +153,7 @@ class ClusterSecretManager:
 
     def delete_cluster_secret(
             self,
-            name: str,
-            namespace: str
+            name: str
     ):
         self.custom_objects_api.delete_cluster_custom_object(
             name=name,

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -180,8 +180,7 @@ class ClusterSecretCases(unittest.TestCase):
         )
 
         self.cluster_secret_manager.delete_cluster_secret(
-            name=name,
-            namespace=USER_NAMESPACES[0],
+            name=name
         )
 
         # We expect the secret to be in NO namespaces

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -55,7 +55,6 @@ def on_field_match_namespace(
     old: Optional[List[str]],
     new: List[str],
     name: str,
-    namespace: str,
     body,
     uid: str,
     logger: logging.Logger,
@@ -91,13 +90,12 @@ def on_field_match_namespace(
     csecs_cache.set_cluster_secret(BaseClusterSecret(
         uid=uid,
         name=name,
-        namespace=namespace,
         body=body,
         synced_namespace=updated_matched,
     ))
 
     # Patch synced_ns field
-    logger.debug(f'Patching clustersecret {name} in namespace {namespace}')
+    logger.debug(f'Patching clustersecret {name}')
     patch_clustersecret_status(
         logger=logger,
         name=name,
@@ -113,7 +111,6 @@ def on_field_data(
     body: Dict[str, Any],
     meta: kopf.Meta,
     name: str,
-    namespace: Optional[str],
     uid: str,
     logger: logging.Logger,
     **_,
@@ -166,7 +163,7 @@ def on_field_data(
 
     if updated_syncedns != syncedns:
         # Patch synced_ns field
-        logger.debug(f'Patching clustersecret {name} in namespace {namespace}')
+        logger.debug(f'Patching clustersecret {name}')
         body = patch_clustersecret_status(
             logger=logger,
             name=name,
@@ -178,7 +175,6 @@ def on_field_data(
     csecs_cache.set_cluster_secret(BaseClusterSecret(
         uid=uid,
         name=name,
-        namespace=namespace or "",
         body=body,
         synced_namespace=updated_syncedns,
     ))
@@ -190,7 +186,6 @@ async def create_fn(
     logger: logging.Logger,
     uid: str,
     name: str,
-    namespace: str,
     body: Dict[str, Any],
     **_
 ):
@@ -211,7 +206,6 @@ async def create_fn(
     csecs_cache.set_cluster_secret(BaseClusterSecret(
         uid=uid,
         name=name,
-        namespace=namespace or "",
         body=body,
         synced_namespace=matchedns,
     ))
@@ -283,7 +277,6 @@ async def startup_fn(logger: logging.Logger, **_):
             BaseClusterSecret(
                 uid=metadata.get('uid'),
                 name=metadata.get('name'),
-                namespace=metadata.get('namespace', ''),
                 body=item,
                 synced_namespace=item.get('status', {}).get('create_fn', {}).get('syncedns', []),
             )

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,5 @@ from pydantic import BaseModel
 class BaseClusterSecret(BaseModel):
     uid: str
     name: str
-    namespace: str
     body: Dict[str, Any]
     synced_namespace: List[str]

--- a/src/tests/test_handlers.py
+++ b/src/tests/test_handlers.py
@@ -26,7 +26,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         csec = BaseClusterSecret(
             uid="mysecretuid",
             name="mysecret",
-            namespace="",
             body={"metadata": {"name": "mysecret", "uid": "mysecretuid"}, "data": {"key": "oldvalue"}},
             synced_namespace=[],
         )
@@ -42,7 +41,6 @@ class TestClusterSecretHandler(unittest.TestCase):
             body=new_body,
             meta=kopf.Meta({"metadata": {"name": "mysecret"}}),
             name="mysecret",
-            namespace=None,
             uid="mysecretuid",
             logger=self.logger,
         )
@@ -75,7 +73,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         csec = BaseClusterSecret(
             uid="mysecretuid",
             name="mysecret",
-            namespace="",
             body={
                 "metadata": {"name": "mysecret", "uid": "mysecretuid"},
                 "data": {"key": "oldvalue"},
@@ -100,7 +97,6 @@ class TestClusterSecretHandler(unittest.TestCase):
                 body=new_body,
                 meta=kopf.Meta({"metadata": {"name": "mysecret"}}),
                 name="mysecret",
-                namespace=None,
                 uid="mysecretuid",
                 logger=self.logger,
             )
@@ -203,7 +199,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         csec = BaseClusterSecret(
             uid="mysecretuid",
             name="mysecret",
-            namespace="",
             body={
                 "metadata": {"name": "mysecret", "uid": "mysecretuid"},
                 "data": {"key": "oldvalue"},
@@ -229,7 +224,6 @@ class TestClusterSecretHandler(unittest.TestCase):
                 body=new_body,
                 meta=kopf.Meta({"metadata": {"name": "mysecret"}}),
                 name="mysecret",
-                namespace=None,
                 uid="mysecretuid",
                 logger=self.logger,
             )
@@ -265,7 +259,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         body = {
             "metadata": {
                 "name": "mysecret",
-                "namespace": "myclustersecretnamespace",
                 "uid": "mysecretuid"
             },
             "data": {"key": "value"}
@@ -284,15 +277,14 @@ class TestClusterSecretHandler(unittest.TestCase):
                     logger=self.logger,
                     uid="mysecretuid",
                     name="mysecret",
-                    namespace="myclustersecretnamespace",
                     body=body,
                 )
             )
 
-        # ClusterSecret with a correct namespace should be in the cache.
+        # The secrets should be in all namespaces of the cache.
         self.assertEqual(
-            csecs_cache.get_cluster_secret("mysecretuid").namespace,
-            "myclustersecretnamespace",
+            csecs_cache.get_cluster_secret("mysecretuid").synced_namespace,
+            ["default", "myns"],
         )
 
     def test_ns_create(self):
@@ -312,7 +304,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         csec = BaseClusterSecret(
             uid="mysecretuid",
             name="mysecret",
-            namespace="",
             body={"metadata": {"name": "mysecret"}, "data": "mydata"},
             synced_namespace=["default"],
         )
@@ -358,7 +349,6 @@ class TestClusterSecretHandler(unittest.TestCase):
         csec = BaseClusterSecret(
             uid="mysecretuid",
             name="mysecret",
-            namespace="",
             body={"metadata": {"name": "mysecret", "uid": "mysecretuid"}, "data": "mydata"},
             synced_namespace=[],
         )


### PR DESCRIPTION
After changing (a long time ago) the scope of 'ClusterSecret' from namespaced to cluster-wide there was left few references to 'namespace' in code of operator and in test's files. This PR for removing those references and also for resolving errors like this:

`[ERROR   ] [dynamic-cluster-secret-match-namespaces] Handler 'on_field_match_namespace/matchNamespace' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/kopf/_core/actions/execution.py", line 276, in execute_handler_once
    result = await invoke_handler(
  File "/usr/local/lib/python3.9/site-packages/kopf/_core/actions/execution.py", line 371, in invoke_handler
    result = await invocation.invoke(
  File "/usr/local/lib/python3.9/site-packages/kopf/_core/actions/invocation.py", line 139, in invoke
    await asyncio.shield(future)  # slightly expensive: creates tasks
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/src/handlers.py", line 91, in on_field_match_namespace
    csecs_cache.set_cluster_secret(BaseClusterSecret(
  File "/usr/local/lib/python3.9/site-packages/pydantic/main.py", line 165, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 1 validation error for BaseClusterSecret
namespace
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.3/v/string_type`

And same error is there: [issuecomment-2090803901]( https://github.com/zakkg3/ClusterSecret/issues/112#issuecomment-2090803901)

After this PR all tests from 'src/tests' and from 'conformance' are passed.

There is similar PR for this purpose **[154](https://github.com/zakkg3/ClusterSecret/pull/154)** , but I think my PR is more clear and resolve only 'namespace' problem (problem with 'on.field' for 'data' I will try to solve in another PR soon).