### PR TITLE
Fix for 'avoidNamespaces' field updates

### DIFF
--- a/charts/cluster-secret/Chart.yaml
+++ b/charts/cluster-secret/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-secret
 description: ClusterSecret Operator
 kubeVersion: '>= 1.25.0-0'
 type: application
-version: 0.5.1
+version: 0.5.2
 icon: https://clustersecret.com/assets/csninjasmall.png
 sources:
 - https://github.com/zakkg3/ClusterSecret

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -188,7 +188,7 @@ class ClusterSecretCases(unittest.TestCase):
             self.cluster_secret_manager.validate_namespace_secrets(
                 name=name,
                 data={"username": username_data},
-                namespaces=[],
+                check_missing=True,
             ),
             f'secret {name} should be deleted from all namespaces.'
         )

--- a/src/tests/test_handlers.py
+++ b/src/tests/test_handlers.py
@@ -43,6 +43,7 @@ class TestClusterSecretHandler(unittest.TestCase):
             name="mysecret",
             uid="mysecretuid",
             logger=self.logger,
+            reason="update",
         )
 
         # New data should be in the cache.
@@ -99,6 +100,7 @@ class TestClusterSecretHandler(unittest.TestCase):
                 name="mysecret",
                 uid="mysecretuid",
                 logger=self.logger,
+                reason="update",
             )
 
         # Namespaced secret should be updated.
@@ -226,6 +228,7 @@ class TestClusterSecretHandler(unittest.TestCase):
                 name="mysecret",
                 uid="mysecretuid",
                 logger=self.logger,
+                reason="update",
             )
 
         # Namespaced secret should be updated with the new data.


### PR DESCRIPTION
This is simple fix for issue [**93**](https://github.com/zakkg3/ClusterSecret/issues/93). It adds an additional '@kopf.on.field' decorator for update events on 'avoidNamespaces' field. After this PR all tests are passed successfully.