### PR TITLE
Improvement. Automatic synchronization of changes from 'linked' secrets

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -257,6 +257,19 @@ async def namespace_watcher(logger: logging.Logger, meta: kopf.Meta, **_):
             custom_objects_api=custom_objects_api,
         )
 
+@kopf.on.update('', 'v1', 'secrets')
+async def on_secret_update(logger: logging.Logger, name: str, namespace: str, **_):
+    """Watch for secret update events
+    """
+    for cached_cluster_secret in csecs_cache.all_cluster_secret():
+        body = cached_cluster_secret.body
+
+        if 'valueFrom' not in body['data']:
+            continue
+        elif name == body['data']['valueFrom']['secretKeyRef']['name'] and namespace == body['data']['valueFrom']['secretKeyRef']['namespace']:
+            logger.info(f'Secret {name} in namespace {namespace}, which linked with ClusterSecret {cached_cluster_secret.name} was changed. Re-syncing')
+            for ns in cached_cluster_secret.synced_namespace:
+                sync_secret(logger, ns, body, v1)
 
 @kopf.on.startup()
 async def startup_fn(logger: logging.Logger, **_):


### PR DESCRIPTION
This PR adds a long-requested and missing feature: automatically updating all secrets when there are changes in secrets referenced by 'secretKeyRef'. A kopf decorator is used to send all secret update events to a new function called 'on_secret_update'. In this function, I parse all ClusterSecrets from the in-memory cache (it's very fast) and check whether they have a 'valueFrom' field in their data. Next, for those ClusterSecrets that have a 'valueFrom' field, I simply compare the name and namespace of the updated secret with the corresponding values in 'valueFrom'. If they match, a resync is initiated for each previously synced namespace.
It will solve [**36**](https://github.com/zakkg3/ClusterSecret/issues/36)