### PR TITLE
BREAKING. Support for namespace label matching and secret event handling

### DIFF
--- a/charts/cluster-secret/crds/clustersecret-crd.yaml
+++ b/charts/cluster-secret/crds/clustersecret-crd.yaml
@@ -28,7 +28,7 @@ spec:
           data:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-          matchLabel:
+          matchLabels:
             additionalProperties:
               type: string
             type: object

--- a/charts/cluster-secret/crds/clustersecret-crd.yaml
+++ b/charts/cluster-secret/crds/clustersecret-crd.yaml
@@ -20,29 +20,49 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
+        type: object
         properties:
           avoidNamespaces:
+            type: array
             items:
               type: string
-            type: array
           data:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+          fromSecret:
+            type: object
+            properties:
+              name:
+                type: string
+              namespace:
+                type: string
+              keys:
+                type: array
+                items:
+                  type: string
+            required:
+            - name
+            - namespace
           matchLabels:
+            type: object
             additionalProperties:
               type: string
-            type: object
           matchNamespace:
+            type: array
             items:
               type: string
-            type: array
           matchedSetsJoin:
             type: string
+            description: intersection or union.  Operation to use when combining namespace sets from multiple labels or label and matchNamespace list
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
           type:
             type: string
-        type: object
+        oneOf:
+        - required:
+          - data
+        - required:
+          - fromSecret
     served: true
     storage: true

--- a/charts/cluster-secret/crds/clustersecret-crd.yaml
+++ b/charts/cluster-secret/crds/clustersecret-crd.yaml
@@ -28,10 +28,16 @@ spec:
           data:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+          matchLabel:
+            additionalProperties:
+              type: string
+            type: object
           matchNamespace:
             items:
               type: string
             type: array
+          matchedSetsJoin:
+            type: string
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -1,6 +1,6 @@
 imagePullSecrets: []
 image:
-  repository: artifactory.ulinedm.com/docker/openshift/uclustersecret
+  repository: quay.io/clustersecret/clustersecret
   tag: 0.0.12
   # use tag-alt for ARM and other alternative builds - read the readme for more information
 

--- a/charts/cluster-secret/values.yaml
+++ b/charts/cluster-secret/values.yaml
@@ -1,6 +1,6 @@
 imagePullSecrets: []
 image:
-  repository: quay.io/clustersecret/clustersecret
+  repository: artifactory.ulinedm.com/docker/openshift/uclustersecret
   tag: 0.0.12
   # use tag-alt for ARM and other alternative builds - read the readme for more information
 

--- a/conformance/cluster-secrets.yaml
+++ b/conformance/cluster-secrets.yaml
@@ -2,7 +2,6 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 data:
   username: MTIzNDU2Cg==
   password: MTIzNDU2Cg==
@@ -11,7 +10,6 @@ kind: ClusterSecret
 apiVersion: clustersecret.io/v1
 metadata:
   name: typed-secret
-  namespace: example-1
   type: kubernetes.io/tls
 data:
   tls.crt: MTIzNDU2Cg==
@@ -21,7 +19,6 @@ apiVersion: clustersecret.io/v1
 kind: ClusterSecret
 metadata:
   name: basic-cluster-secret
-  namespace: example-1
 avoidNamespaces:
   - example-3
 ---

--- a/conformance/k8s_utils.py
+++ b/conformance/k8s_utils.py
@@ -153,8 +153,7 @@ class ClusterSecretManager:
 
     def delete_cluster_secret(
             self,
-            name: str,
-            namespace: str
+            name: str
     ):
         self.custom_objects_api.delete_cluster_custom_object(
             name=name,

--- a/conformance/tests.py
+++ b/conformance/tests.py
@@ -181,7 +181,6 @@ class ClusterSecretCases(unittest.TestCase):
 
         self.cluster_secret_manager.delete_cluster_secret(
             name=name,
-            namespace=USER_NAMESPACES[0],
         )
 
         # We expect the secret to be in NO namespaces
@@ -212,7 +211,6 @@ class ClusterSecretCases(unittest.TestCase):
             name=cluster_secret_name,
             secret_key_ref={
                 'name': secret_name,
-                'namespace': USER_NAMESPACES[0],
             },
         )
 
@@ -245,7 +243,6 @@ class ClusterSecretCases(unittest.TestCase):
             name=cluster_secret_name,
             secret_key_ref={
                 'name': secret_name,
-                'namespace': USER_NAMESPACES[0],
                 'keys': ['username', 'password']
             },
         )

--- a/src/consts.py
+++ b/src/consts.py
@@ -2,9 +2,6 @@
 Constants used by the project
 """
 
-CREATE_BY_ANNOTATION = 'clustersecret.io/created-by'
-CREATE_BY_AUTHOR = 'ClusterSecrets'
-LAST_SYNC_ANNOTATION = 'clustersecret.io/last-sync'
 VERSION_ANNOTATION = 'clustersecret.io/version'
 
 CLUSTER_SECRET_LABEL = "clustersecret.io"

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -97,7 +97,7 @@ def on_match_fields(
     ))
 
     # Patch synced_ns field
-    logger.debug(f'Patching clustersecret {name} in namespace {namespace}')
+    logger.debug(f'Patching clustersecret {name}')
     patch_clustersecret_status(
         logger=logger,
         name=name,
@@ -178,7 +178,6 @@ async def create_fn(
 async def namespace_watcher(logger: logging.Logger, meta: kopf.Meta, **_):
     """Watch for namespace events
     """
-    logger.setLevel(logging.DEBUG)
     ns = meta.name
     logger.debug(f'Namespace event: {ns} re-syncing')
     for cluster_secret in csecs_cache.all_cluster_secret():

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -140,6 +140,14 @@ def on_field_data(
         logger.info(f'Re Syncing secret {name} in ns {ns}')
         sync_secret(logger, ns, body, v1)
 
+    # Updating the cache
+    csecs_cache.set_cluster_secret(BaseClusterSecret(
+        uid=uid,
+        name=name,
+        body=body,
+        synced_namespace=syncedns,
+    ))
+
 
 @kopf.on.resume('clustersecret.io', 'v1', 'clustersecrets')
 @kopf.on.create('clustersecret.io', 'v1', 'clustersecrets')

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -166,17 +166,13 @@ async def create_fn(
         synced_namespace=matchedns,
     ))
 
-    # store status in memory
-    cached_cluster_secret = csecs_cache.get_cluster_secret(uid)
-    if cached_cluster_secret is None:
-        logger.error('Received an event for an unknown ClusterSecret.')
-
 
 @kopf.on.create('', 'v1', 'namespaces')
 @kopf.on.field('', 'v1', 'namespaces', field='metadata.labels')
 async def namespace_watcher(logger: logging.Logger, meta: kopf.Meta, **_):
     """Watch for namespace events
     """
+    logger.setLevel(logging.DEBUG)
     ns = meta.name
     logger.debug(f'Namespace event: {ns} re-syncing')
     for cluster_secret in csecs_cache.all_cluster_secret():

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -51,16 +51,18 @@ def on_delete(
 
 
 @kopf.on.field('clustersecret.io', 'v1', 'clustersecrets', field='matchNamespace')
+@kopf.on.field('clustersecret.io', 'v1', 'clustersecrets', field='matchLabels')
+@kopf.on.field('clustersecret.io', 'v1', 'clustersecrets', field='matchedSetsJoin')
 def on_field_match_namespace(
     old: Optional[List[str]],
     new: List[str],
     name: str,
-    namespace: str,
     body,
     uid: str,
     logger: logging.Logger,
     **_,
 ):
+    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
     logger.debug(f'Namespaces changed: {old} -> {new}')
 
     if old is None:
@@ -113,11 +115,11 @@ def on_field_data(
     body: Dict[str, Any],
     meta: kopf.Meta,
     name: str,
-    namespace: Optional[str],
     uid: str,
     logger: logging.Logger,
     **_,
 ):
+    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
     logger.debug(f'Data changed: {old} -> {new}')
     if old is None:
         logger.debug('This is a new object: Ignoring')
@@ -135,53 +137,7 @@ def on_field_data(
     updated_syncedns = syncedns.copy()
     for ns in syncedns:
         logger.info(f'Re Syncing secret {name} in ns {ns}')
-        ns_sec_body = client.V1Secret(
-            api_version='v1',
-            data={str(key): str(value) for key, value in new.items()},
-            kind='Secret',
-            metadata=create_secret_metadata(
-                name=name,
-                namespace=ns,
-                annotations={str(key): str(value) for key, value in meta.annotations.items()},
-                labels={str(key): str(value) for key, value in meta.labels.items()},
-            ),
-            type=secret_type,
-        )
-        logger.debug(f'body: {ns_sec_body}')
-        # Ensuring the secret still exist.
-        if secret_exists(logger=logger, name=name, namespace=ns, v1=v1):
-            response = v1.replace_namespaced_secret(name=name, namespace=ns, body=ns_sec_body)
-        else:
-            try:
-                v1.read_namespace(name=ns)
-            except client.exceptions.ApiException as e:
-                if e.status != 404:
-                    raise
-                response = f'Namespace {ns} not found'
-                updated_syncedns.remove(ns)
-                logger.info(f'Namespace {ns} not found while Syncing secret {name}')
-            else:
-                response = v1.create_namespaced_secret(namespace=ns, body=ns_sec_body)
-        logger.debug(response)
-
-    if updated_syncedns != syncedns:
-        # Patch synced_ns field
-        logger.debug(f'Patching clustersecret {name} in namespace {namespace}')
-        body = patch_clustersecret_status(
-            logger=logger,
-            name=name,
-            new_status={'create_fn': {'syncedns': updated_syncedns}},
-            custom_objects_api=custom_objects_api,
-        )
-
-    # Updating the cache
-    csecs_cache.set_cluster_secret(BaseClusterSecret(
-        uid=uid,
-        name=name,
-        namespace=namespace or "",
-        body=body,
-        synced_namespace=updated_syncedns,
-    ))
+        sync_secret(logger, ns, body, v1)
 
 
 @kopf.on.resume('clustersecret.io', 'v1', 'clustersecrets')
@@ -190,12 +146,12 @@ async def create_fn(
     logger: logging.Logger,
     uid: str,
     name: str,
-    namespace: str,
     body: Dict[str, Any],
     **_
 ):
     # get all ns matching.
     matchedns = get_ns_list(logger, body, v1)
+    namespace = body['data']['valueFrom']['secretKeyRef']['namespace']
 
     # sync in all matched NS
     logger.info(f'Syncing on Namespaces: {matchedns}')

--- a/src/kubernetes_utils.py
+++ b/src/kubernetes_utils.py
@@ -160,8 +160,8 @@ def secret_belongs(
         csec_body: Dict[str, Any],
         ns_meta: Dict[str, Any],
 ):
-    ns_name = ns_meta.name
-    ns_labels = ns_meta.labels
+    ns_name = ns_meta.get('name', None)
+    ns_labels = ns_meta.get('labels', {})
 
     # Get avoidNamespaces or default to empty list
     avoid_namespaces = csec_body.get('avoidNamespaces', [])

--- a/src/kubernetes_utils.py
+++ b/src/kubernetes_utils.py
@@ -1,21 +1,22 @@
 import logging
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Mapping, Tuple, Iterator
+from cache import Cache
 import re
 
 import kopf
-from kubernetes.client import CoreV1Api, CustomObjectsApi, exceptions, V1ObjectMeta, rest, V1Secret
+from kubernetes.client import CoreV1Api, CustomObjectsApi, exceptions, V1ObjectMeta, V1OwnerReference, rest, V1Secret
 
+from models import BaseClusterSecret
 from os_utils import get_replace_existing, get_version
-from consts import CREATE_BY_ANNOTATION, LAST_SYNC_ANNOTATION, VERSION_ANNOTATION, BLACK_LISTED_ANNOTATIONS, \
-    BLACK_LISTED_LABELS, CREATE_BY_AUTHOR, CLUSTER_SECRET_LABEL
+from consts import VERSION_ANNOTATION, BLACK_LISTED_ANNOTATIONS, BLACK_LISTED_LABELS, CLUSTER_SECRET_LABEL
 
 
 def patch_clustersecret_status(
-    logger: logging.Logger,
-    name: str,
-    new_status,
-    custom_objects_api: CustomObjectsApi,
+        logger: logging.Logger,
+        name: str,
+        new_status,
+        custom_objects_api: CustomObjectsApi,
 ):
     """Patch the status of a given clustersecret object
     """
@@ -98,30 +99,6 @@ def get_ns_list(
     return list(set(matched_ns) - set(avoided_ns))
 
 
-def read_data_secret(
-        logger: logging.Logger,
-        name: str,
-        namespace: str,
-        v1: CoreV1Api,
-) -> Dict[str, str]:
-    """Gets the data from the 'name' secret in namespace
-    """
-    data = {}
-    logger.debug(f'Reading {name} from ns {namespace}')
-    try:
-        secret = v1.read_namespaced_secret(name, namespace)
-
-        logger.debug(f'Obtained secret {secret}')
-        data = secret.data
-    except exceptions.ApiException as e:
-        logger.error('Error reading secret')
-        logger.debug(f'error: {e}')
-        if e == '404':
-            logger.error(f'Secret {name} in ns {namespace} not found.')
-        raise kopf.TemporaryError('Error reading secret')
-    return data
-
-
 def delete_secret(
         logger: logging.Logger,
         namespace: str,
@@ -158,11 +135,9 @@ def secret_exists(
 def secret_belongs(
         logger: logging.Logger,
         csec_body: Dict[str, Any],
-        ns_meta: Dict[str, Any],
+        ns_name: str,
+        ns_labels: Dict[str, str],
 ):
-    ns_name = ns_meta.get('name', None)
-    ns_labels = ns_meta.get('labels', {})
-
     # Get avoidNamespaces or default to empty list
     avoid_namespaces = csec_body.get('avoidNamespaces', [])
 
@@ -199,20 +174,40 @@ def secret_belongs(
     return is_match
 
 
-def secret_metadata(
+def sync_clustersecret(
         logger: logging.Logger,
-        name: str,
-        namespace: str,
+        body: Dict[str, Any],
+        csecs_cache: Cache,
         v1: CoreV1Api,
-) -> Optional[V1ObjectMeta]:
-    try:
-        secret = v1.read_namespaced_secret(name, namespace)
-        return secret.metadata
-    except exceptions.ApiException as e:
-        if e.status == 404:
-            return None
-        logger.warning(f'Cannot read the secret {e}.')
-        raise kopf.TemporaryError(f'Error reading secret {e}')
+        custom_objects_api: CustomObjectsApi,
+):
+    meta = body.get('metadata',{})
+    name = meta.get('name')
+
+    # get all ns matching.
+    matchedns = get_ns_list(logger, body, v1)
+
+    # sync in all matched NS
+    logger.info(f'Syncing on Namespaces: {matchedns}')
+    for ns in matchedns:
+        sync_secret(logger, ns, body, v1)
+
+    # Updating the cache
+    csecs_cache.set_cluster_secret(BaseClusterSecret(
+        uid=meta.get('uid'),
+        name=name,
+        body=body,
+        synced_namespace=matchedns,
+    ))
+
+    # Patch synced_ns field
+    logger.debug(f'Patching clustersecret {name}')
+    patch_clustersecret_status(
+        logger=logger,
+        name=name,
+        new_status={'syncedns': matchedns},
+        custom_objects_api=custom_objects_api,
+    )
 
 
 def sync_secret(
@@ -223,84 +218,73 @@ def sync_secret(
 ):
     """Creates a given secret on a given namespace
     """
-    if 'metadata' not in body:
-        raise kopf.TemporaryError('Metadata is required.')
-
-    if 'name' not in body['metadata']:
-        raise kopf.TemporaryError('Property name is missing in metadata.')
-
     cs_metadata: Dict[str, Any] = body.get('metadata')
     sec_name = cs_metadata.get('name')
     annotations = cs_metadata.get('annotations', None)
     labels = cs_metadata.get('labels', None)
 
-    if 'data' not in body:
-        raise kopf.TemporaryError('Property data is missing.')
-
-    data: Dict[str, Any] = body['data']
-
-    if 'valueFrom' in data:
-        if len(data.keys()) > 1:
-            logger.error('Data keys with ValueFrom error, enable debug for more details')
-            logger.debug(f'keys: {data.keys()}  len {len(data.keys())}')
-            raise kopf.TemporaryError('ValueFrom can not coexist with other keys in the data')
-
-        secret_key_ref: Dict[str, Any] = data.get('valueFrom', {}).get('secretKeyRef', {})
-        ns_from: str = secret_key_ref.get('namespace', None)
-        name_from: str = secret_key_ref.get('name', None)
-        keys: Optional[List[str]] = secret_key_ref.get('keys', None)
-
-        if ns_from is None or name_from is None:
-            logger.error('ERROR reading data from remote secret, enable debug for more details')
-            logger.debug(f'Deta details: {data}')
-            raise kopf.TemporaryError('Can not get Values from external secret')
+    if 'data' in body:
+        data = body.get('data')
+    elif 'fromSecret' in body:
+        secret_key_ref: Dict[str, Any] = body.get('fromSecret', {})
+        from_ns: str = secret_key_ref.get('namespace')
+        from_name: str = secret_key_ref.get('name')
+        keys: Optional[List[str]] = secret_key_ref.get('keys')
 
         # Filter the keys in data based on the keys list provided
-        raw_data = read_data_secret(logger, name_from, ns_from, v1)
+        try:
+            from_secret = v1.read_namespaced_secret(from_name, from_ns)
+            logger.debug(f'Obtained secret {from_secret}')
+            raw_data = from_secret.data
+        except exceptions.ApiException as e:
+            logger.error(f'Cannot read source secret {from_name} in namespace {from_ns}. enable debug for details')
+            logger.debug(f'Kube exception {e}')
+            return
         if keys is not None:
             data = {key: value for key, value in raw_data.items() if key in keys}
         else:
             data = raw_data
 
-    logger.debug(f'Going to create with data: {data}')
-    secret_type = body.get('type', 'Opaque')
+    else:
+        return
 
-    body = V1Secret()
-    body.metadata = create_secret_metadata(
+    logger.debug(f'Going to create with data: {data}')
+    sec_type = body.get('type', 'Opaque')
+
+    sec_body = V1Secret()
+    sec_body.metadata = create_secret_metadata(
         name=sec_name,
         namespace=namespace,
+        csec_body=body,
         annotations=annotations,
         labels=labels,
     )
-    body.type = secret_type
-    body.data = data
-    logger.info(f'cloning secret {sec_name} into namespace {namespace}')
-    logger.debug(f'V1Secret= {body}')
+    sec_body.type = sec_type
+    sec_body.data = data
+    logger.info(f'syncing secret {sec_name} in namespace {namespace}')
+    logger.debug(f'V1Secret= {sec_body}')
 
     try:
-        # Get metadata from secrets (if exist)
-        metadata = secret_metadata(logger, name=sec_name, namespace=namespace, v1=v1)
+        # Get secret
+        try:
+            secret = v1.read_namespaced_secret(sec_name, namespace)
+        except exceptions.ApiException as e:
+            if e.status == 404:
+                secret = None
+            else:
+                logger.error(f'Cannot read secret {sec_name} in namespace {namespace}. enable debug for details')
+                logger.debug(f'Kube exception {e}')
+                return
 
         # If nothing returned, the secret does not exist, creating it then
-        if metadata is None:
+        if secret is None:
             logger.info('Using create_namespaced_secret')
-            logger.debug(f'response is {v1.create_namespaced_secret(namespace, body)}')
+            logger.debug(f'response is {v1.create_namespaced_secret(namespace, sec_body)}')
             return
 
-        if metadata.annotations is None:
-            logger.info(
-                f'secret `{sec_name}` exist but it does not have annotations, so is not managed by ClusterSecret',
-            )
-
-            # If we should not overwrite existing secrets
-            if not get_replace_existing():
-                logger.info(
-                    f'secret `{sec_name}` will not be replaced. '
-                    'You can enforce this by setting env REPLACE_EXISTING to true.',
-                )
-                return
-        elif metadata.annotations.get(CREATE_BY_ANNOTATION) is None:
-            logger.error(
+        metadata = secret.metadata
+        if not metadata.owner_references or metadata.owner_references[0].kind != 'ClusterSecret':
+            logger.warning(
                 f"secret `{sec_name}` already exist in namespace '{namespace}' and is not managed by ClusterSecret",
             )
 
@@ -311,12 +295,17 @@ def sync_secret(
                 )
                 return
 
-        logger.info(f'Replacing secret {sec_name}')
-        v1.replace_namespaced_secret(
-            name=sec_name,
-            namespace=namespace,
-            body=body,
-        )
+        if (secret.data != sec_body.data or
+            not secret.metadata.labels.items() >= sec_body.metadata.labels.items() or
+            not secret.metadata.annotations.items() >= sec_body.metadata.annotations.items() or
+            secret.metadata.owner_references != sec_body.metadata.owner_references
+        ):
+            logger.info(f'Replacing secret {sec_name}')
+            v1.replace_namespaced_secret(
+                name=sec_name,
+                namespace=namespace,
+                body=sec_body,
+            )
     except rest.ApiException as e:
         logger.error('Can not create a secret, it is base64 encoded? enable debug for details')
         logger.debug(f'data: {data}')
@@ -326,6 +315,7 @@ def sync_secret(
 def create_secret_metadata(
         name: str,
         namespace: str,
+        csec_body: Dict[str, Any],
         annotations: Optional[Mapping[str, str]] = None,
         labels: Optional[Mapping[str, str]] = None,
 ) -> V1ObjectMeta:
@@ -337,6 +327,8 @@ def create_secret_metadata(
         The name of the Kubernetes secret.
     namespace: str
         The namespace where the secret will be place.
+    csec_body: Dict[str, Any]
+        The body of the clustersecret
     labels: Optional[Dict[str, str]]
         The secret labels.
     annotations: Optional[Dict[str, str]]
@@ -366,16 +358,25 @@ def create_secret_metadata(
         CLUSTER_SECRET_LABEL: 'true'
     }
     base_annotations = {
-        CREATE_BY_ANNOTATION: CREATE_BY_AUTHOR,
         VERSION_ANNOTATION: get_version(),
-        LAST_SYNC_ANNOTATION: datetime.now().isoformat(),
     }
+
+    # Create directly instead of with kopf.adopt to handle namespace events
+    owner_reference = V1OwnerReference(
+        api_version = csec_body.get('apiVersion', None),
+        block_owner_deletion = True,
+        controller = True,
+        kind = csec_body.get('kind', None),
+        name = csec_body.get('metadata', {}).get('name', None),
+        uid = csec_body.get('metadata', {}).get('uid', None)
+    )
 
     _annotations = filter_dict(BLACK_LISTED_ANNOTATIONS, base_annotations, annotations)
     _labels = filter_dict(BLACK_LISTED_LABELS, base_labels, labels)
     return V1ObjectMeta(
         name=name,
         namespace=namespace,
+        owner_references=[owner_reference],
         annotations=dict(_annotations),
         labels=dict(_labels),
     )

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,5 @@ from pydantic import BaseModel
 class BaseClusterSecret(BaseModel):
     uid: str
     name: str
-    namespace: str
     body: Dict[str, Any]
     synced_namespace: List[str]


### PR DESCRIPTION
The two functional goals of this PR are:

1. To respond to secret events (recreate deleted secrets, re-sync changed secrets, sync all target secrets when a source secret changes).
1. To support namespace label matching for target namespaces.

Many changes were made to support these two functional goals, and more changes were made to simplify the code.  I categorize these changes as breaking, functional, and cleanup.
### BREAKING

1. `valueFrom` inside the `data` field will no longer designate a source secret.  To use a secret as the source, a new `fromSecret` field (an object with required strings `name` and `namespace` and optional string array `keys`) is added to the CRD.  A ClusterSecret will only be valid if it has one of `data` or `fromSecret`, but not both.
1. Creator/owner checking is done through `ownerReferences` on secrets (instead of the `CREATE_BY_ANNOTATION`) now, which will break installations with `REPLACE_EXISTING: false` as the controller will refuse to update preexisting secrets.
### Functional

1. To support namespace label matching, two new fields were added to the CRD: `matchLabels` and `matchedSetsJoin`
   * `matchLabels` takes objects with string values.  It looks the same as labels set on a kubernetes resource.
   * `matchedSetsJoin` takes a string with value "union" or "intersection" and performs that operation to join the namespace lists generated by each `matchLabel` and by `matchNamespace`.
   * The logic for both new fields is in `get_ns_list` and duplicated in a new `secret_belongs` function.
1. Since we need to track more than just namespace creation, the handler is renamed to `on_namespace_event` and is triggered by `kopf.on.event` instead of `kopf.on.create` (this also prevents kopf from setting the status field on namespace resources, which seemed excessive).  The handler uses the new `secret_belongs` function to check every clustersecret to find if any match the new namespace state and syncs, deletes, or does nothing to reach the desired state.
1. The `secret_belongs` function is added to check if a single namespace matches a clustersecret.  This allows us to avoid a full `get_ns_list` call when only one namespace or secret changes.
1. The `on_field_match_namespace` handler is renamed to `on_match_fields` and handles events for changes to the `matchNamespace`, `matchLabels`, and `matchedSetsJoin` fields.
1. The `on_field_data` handler now also handles events for changes to the `fromSecret` field.
1. To support secret event handling, a new `on_secret_event` handler is added to both re-sync secrets managed by a ClusterSecret (determined by whether an `ownerReference` with `kind: ClusterSecret` is set on the secret) and trigger a full cluster secret re-sync if the changed secret is the source for a ClusterSecret.
1. The `create_secret_metadata` function now adds an `ownerReference` to managed secrets' metadata.  This is used by the `on_secret_event` handler and allows us to reduce the `on_delete` handler as secret deletion will be handled by kubernetes on clustersecret deletion.
### Cleanup

1. The `CREATE_BY_ANNOTATION` is removed from secrets in favor of `ownerReferences`.
2. The `on_delete` handler is reduced to only removing the deleted ClusterSecret from the cache, as all secrets are now deleted by kubernetes through the `ownerReferences`.
3. ClusterSecrets are cluster-scoped resources.  All references to ClusterSecret namespace are removed.
4. The `LAST_SYNC_ANNOTATION` is removed from secrets.  It seems unnecessary and complicates current vs desired state comparisons done before secret updates.  If added again, the `sync_secret` function will need to be updated to ignore this annotation when comparing desired to current secret states.
5. A new function `secret_belongs` is added to test whether a single namespace matches a ClusterSecret.
6. A new function `sync_clustersecret` is added to sync all targets of a ClusterSecret.
7. The `startup_fn` handler now syncs all ClusterSecrets found in the cluster on operator start.  The `create_fn` handler no longer handles ClusterSecret resume events.
8. The `syncedns` field in secret resources is now directly under `status` instead of `status.create_fn`.  The `create_fn` handler uses the new `sync_clustersecret` function, which includes status patching, and no longer returns the syncedns list to kopf.
9. A new `fromSecret` field is added to the ClusterSecret CRD, which can be used to designate a source secret.  This allows ClusterSecret structure validation to be handled by kubernetes, and allows `valueFrom` to be a key in ClusterSecret data.
10. ClusterSecret data validation is removed from the `sync_secret` function.  With the new CRD the validations are unnecessary.
11. The `read_data_secret` function is moved into the `sync_secret` function, the only calling location.


This PR is not ready to be merged.  There are several TODOs and a few potential improvements.
###TODO
1. Increment version
2. Update documentation
3. Update tests

###Potential Improvements
1. Update CRD to limit `data` field to only key/value pairs with string values now that `valueFrom` in `data` is unsupported (see `matchLabels` definition).
2. Validate `matchedSetsJoin` string (ensure it's one of union or intersection) - can this be done in the CRD?
3. Remove the cache - all comparisons could be done against cluster state instead of cached state.
4. Remove `syncedns` from ClusterSecret status - deletion of secrets that used to match would need to be handled differently.
5. Logging changes - after many code changes there may be logs that no longer make sense, and there are likely new operations that would benefit from new log output.